### PR TITLE
Handle non-privileged users calling admin CGIs

### DIFF
--- a/axis/mqtt.py
+++ b/axis/mqtt.py
@@ -93,6 +93,9 @@ class MqttClient(APIItems):
     def __init__(self, raw: dict, request: object) -> None:
         super().__init__(raw, request, URL_CLIENT, Client)
 
+    def update(self) -> None:
+        """No update method"""
+
     def configure_client(self, client_config: ClientConfig) -> None:
         """Configure MQTT Client."""
         self._request(


### PR DESCRIPTION
If api discovery call passes but get unauthorized on subsequent api calls we can expect the user to be a viewer or operator