### PR TITLE
Split user properties at first occurrence of `=`

### DIFF
--- a/axis/pwdgrp_cgi.py
+++ b/axis/pwdgrp_cgi.py
@@ -79,7 +79,7 @@ class Users(APIItems):
         Prepare users to work with APIItems.
         Create booleans with user levels.
         """
-        raw_dict = dict(group.split("=") for group in raw.splitlines())
+        raw_dict = dict(group.split("=", 1) for group in raw.splitlines())
 
         raw_users = {
             user: {

--- a/tests/test_pwdgrp_cgi.py
+++ b/tests/test_pwdgrp_cgi.py
@@ -119,6 +119,13 @@ def test_delete():
     )
 
 
+def test_equals_in_value():
+    """Verify that values containing `=` are parsed correctly."""
+    mock_request = Mock()
+    fixture_with_equals = fixture + "equals-in-value=\"xyz==\""
+    Users(fixture_with_equals, mock_request)
+
+
 fixture = """admin="usera,wwwa,wwwaop,wwwaovp,wwwao,wwwap,wwwaov,root"
 anonymous=""
 api-discovery=""


### PR DESCRIPTION
When parsing user properties containing `=`, e.g.
`digusers="root,hass,xyz=="` dict conversion fails:

	ValueError: dictionary update sequence element #132 has length 4; 2 is required

This change resolves an error where the event stream initializes but
fails to show events from the camera.

Ref home-assistant/core#36850