### PR TITLE
Do not use asynctest with python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
     install_requires=["attrs", "packaging", "requests", "xmltodict"],
     keywords=["axis", "vapix", "onvif", "event stream", "homeassistant"],
     classifiers=["Natural Language :: English", "Programming Language :: Python :: 3"],
+    python_requires=">=3.8.0",
 )

--- a/tests/applications/test_applications.py
+++ b/tests/applications/test_applications.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.applications tests/applications/test_applications.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.applications import Applications
 

--- a/tests/applications/test_fence_guard.py
+++ b/tests/applications/test_fence_guard.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.fence_guard tests/test_fence_guard.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.applications.fence_guard import FenceGuard
 

--- a/tests/applications/test_loitering_guard.py
+++ b/tests/applications/test_loitering_guard.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.loitering_guard tests/test_loitering_guard.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.applications.loitering_guard import LoiteringGuard
 

--- a/tests/applications/test_motion_guard.py
+++ b/tests/applications/test_motion_guard.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.motion_guard tests/test_motion_guard.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.applications.motion_guard import MotionGuard
 

--- a/tests/applications/test_vmd4.py
+++ b/tests/applications/test_vmd4.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.vmd4 tests/test_vmd4.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.applications.vmd4 import Vmd4
 

--- a/tests/test_api_discovery.py
+++ b/tests/test_api_discovery.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.api_discovery tests/test_api_discovery.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.api_discovery import ApiDiscovery, API_DISCOVERY_ID
 

--- a/tests/test_basic_device_info.py
+++ b/tests/test_basic_device_info.py
@@ -5,7 +5,7 @@ pytest --cov-report term-missing --cov=axis.basic_device_info tests/test_basic_d
 
 import pytest
 
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.basic_device_info import BasicDeviceInfo
 

--- a/tests/test_basic_device_info.py
+++ b/tests/test_basic_device_info.py
@@ -4,7 +4,6 @@ pytest --cov-report term-missing --cov=axis.basic_device_info tests/test_basic_d
 """
 
 import pytest
-
 from unittest.mock import Mock
 
 from axis.basic_device_info import BasicDeviceInfo

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=axis.device tests/test_device.py
 """
 
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.device import AxisDevice
 from axis.configuration import Configuration

--- a/tests/test_event_services.py
+++ b/tests/test_event_services.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=axis.event_services tests/test_event_services.py
 """
 
-from asynctest import Mock, patch
+from unittest.mock import Mock, patch
 
 from axis.event_services import get_event_list
 

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.event_stream tests/test_event_stream.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.event_stream import EventManager
 

--- a/tests/test_light_control.py
+++ b/tests/test_light_control.py
@@ -4,8 +4,7 @@ pytest --cov-report term-missing --cov=axis.light_control tests/test_light_contr
 """
 
 import pytest
-
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.light_control import LightControl
 

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=axis.mqtt tests/test_mqtt.py
 """
 import pytest
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.mqtt import (
     ClientConfig,

--- a/tests/test_param_cgi.py
+++ b/tests/test_param_cgi.py
@@ -4,8 +4,7 @@ pytest --cov-report term-missing --cov=axis.param_cgi tests/test_param_cgi.py
 """
 
 import pytest
-
-from asynctest import Mock, call
+from unittest.mock import Mock, call
 
 from axis.param_cgi import BRAND, INPUT, IOPORT, OUTPUT, PROPERTIES, Params
 

--- a/tests/test_port_cgi.py
+++ b/tests/test_port_cgi.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=axis.port_cgi tests/test_port_cgi.py
 """
 
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.param_cgi import Params
 from axis.port_cgi import ACTION_LOW, Ports

--- a/tests/test_port_management.py
+++ b/tests/test_port_management.py
@@ -3,15 +3,14 @@
 pytest --cov-report term-missing --cov=axis.port_management tests/test_port_management.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.port_management import (
     IoPortManagement,
     PortSequence,
     Sequence,
     SetPort,
-    API_DISCOVERY_ID,
 )
 
 

--- a/tests/test_pwdgrp_cgi.py
+++ b/tests/test_pwdgrp_cgi.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=axis.pwdgrp_cgi tests/test_pwdgrp_cgi.py
 """
 
-from asynctest import Mock
+from unittest.mock import Mock
 
 from axis.pwdgrp_cgi import SGRP_ADMIN, Users
 
@@ -122,7 +122,7 @@ def test_delete():
 def test_equals_in_value():
     """Verify that values containing `=` are parsed correctly."""
     mock_request = Mock()
-    fixture_with_equals = fixture + "equals-in-value=\"xyz==\""
+    fixture_with_equals = fixture + 'equals-in-value="xyz=="'
     Users(fixture_with_equals, mock_request)
 
 

--- a/tests/test_stream_profiles.py
+++ b/tests/test_stream_profiles.py
@@ -3,8 +3,8 @@
 pytest --cov-report term-missing --cov=axis.stream_profiles tests/test_stream_profiles.py
 """
 
-from asynctest import Mock
 import pytest
+from unittest.mock import Mock
 
 from axis.stream_profiles import StreamProfiles
 

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -3,10 +3,9 @@
 pytest --cov-report term-missing --cov=axis.vapix tests/test_vapix.py
 """
 
-from unittest.mock import call
-from asynctest import Mock, patch
 import json
 import pytest
+from unittest.mock import Mock, call, patch
 
 from axis.errors import Unauthorized
 from axis.applications import APPLICATION_STATE_RUNNING, APPLICATION_STATE_STOPPED


### PR DESCRIPTION
Library now requires python 3.8