### PR TITLE
Add an increased time out to vapix request

### DIFF
--- a/axis/vapix.py
+++ b/axis/vapix.py
@@ -36,6 +36,8 @@ from .user_groups import UNKNOWN, URL as USER_GROUPS_URL, UserGroups
 
 LOGGER = logging.getLogger(__name__)
 
+TIME_OUT = 15
+
 
 class Vapix:
     """Vapix parameter request."""
@@ -261,7 +263,7 @@ class Vapix:
         LOGGER.debug("%s %s", url, kwargs)
         try:
             response = await self.config.session.request(
-                method, url, auth=self.auth, **kwargs
+                method, url, auth=self.auth, timeout=TIME_OUT, **kwargs
             )
             response.raise_for_status()
 
@@ -286,9 +288,8 @@ class Vapix:
             LOGGER.debug("%s, %s", response, errh)
             raise_error(response.status_code)
 
-        except httpx.TimeoutException as errt:
-            LOGGER.debug("%s", errt)
-            raise RequestError("Timeout: {}".format(errt))
+        except httpx.TimeoutException:
+            raise RequestError("Timeout")
 
         except httpx.TransportError as errc:
             LOGGER.debug("%s", errc)


### PR DESCRIPTION
Older devices like the M3027 has quite a high load level when running vmd3 and 4. Together with this library being very aggressive in requesting Vapix data from the device and httpx having a default request time out of 5 seconds it was very common to time out. Users of Home Assistant noticed certain older devices not setting up correctly.