### PR TITLE
Simplify parameter references

### DIFF
--- a/axis/vapix/interfaces/parameters/param_cgi.py
+++ b/axis/vapix/interfaces/parameters/param_cgi.py
@@ -32,19 +32,13 @@ class Params(ApiHandler[Any]):
         self.ptz_handler = PtzParameterHandler(self)
         self.stream_profile_handler = StreamProfileParameterHandler(self)
 
-    def get_param(self, group: ParameterGroup) -> dict[str, Any]:
-        """Get parameter group."""
-        data: dict[str, Any] = self._items.get("root", {}).get(group, {})
-        return data
-
     async def update_group(self, group: ParameterGroup | None = None) -> None:
         """Refresh data."""
         bytes_data = await self.vapix.api_request(ParamRequest(group))
         data = params_to_dict(bytes_data.decode())
 
-        root: dict[str, Any] = self._items.setdefault("root", {})
         if objects := data.get("root"):
-            root.update(objects)
+            self._items.update(objects)
             self.initialized = True
 
             for obj_id in objects:

--- a/axis/vapix/interfaces/parameters/param_cgi.py
+++ b/axis/vapix/interfaces/parameters/param_cgi.py
@@ -23,7 +23,7 @@ class Params(ApiHandler[Any]):
     api_id = ApiId.PARAM_CGI
 
     def __init__(self, vapix: "Vapix") -> None:
-        """Initialize API items."""
+        """Initialize parameter classes."""
         super().__init__(vapix)
 
         self.brand_handler = BrandParameterHandler(self)
@@ -34,12 +34,12 @@ class Params(ApiHandler[Any]):
         self.stream_profile_handler = StreamProfileParameterHandler(self)
 
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
-        """Request parameter data and convert it into a dict."""
+        """Fetch parameter data and convert it into a dictionary."""
         bytes_data = await self.vapix.api_request(ParamRequest(group))
         return params_to_dict(bytes_data.decode()).get("root") or {}
 
     async def _update(self, group: ParameterGroup | None = None) -> Sequence[str]:
-        """Refresh data."""
+        """Request parameter data and update items."""
         objects = await self._api_request(group)
         self._items.update(objects)
         self.initialized = True

--- a/axis/vapix/interfaces/parameters/param_handler.py
+++ b/axis/vapix/interfaces/parameters/param_handler.py
@@ -32,9 +32,9 @@ class ParamHandler(ApiHandler[ParamItemT]):
         return self.vapix.params.get(self.parameter_group) is not None
 
     async def _update(self) -> Sequence[str]:
-        """Request group data from parameter handler.
+        """Request parameter group data from parameter handler.
 
-        This method returns after _update_params_callback have updated items.
+        This method returns after _update_params_callback has updated items.
         """
         return await self.vapix.params.request_group(self.parameter_group)
 

--- a/axis/vapix/interfaces/parameters/param_handler.py
+++ b/axis/vapix/interfaces/parameters/param_handler.py
@@ -28,11 +28,11 @@ class ParamHandler(ApiHandler[ParamItemT]):
     @property
     def supported_by_parameters(self) -> bool:
         """Is parameter group supported."""
-        return self.vapix.params.get_param(self.parameter_group) != {}
+        return self.vapix.params.get(self.parameter_group) is not None
 
     def get_params(self) -> dict[str, ParamItemT]:
         """Retrieve parameters from param_cgi class."""
-        if data := self.vapix.params.get_param(self.parameter_group):
+        if data := self.vapix.params.get(self.parameter_group):
             return self.parameter_item.decode_to_dict([data])
         return {}
 

--- a/axis/vapix/interfaces/parameters/param_handler.py
+++ b/axis/vapix/interfaces/parameters/param_handler.py
@@ -30,19 +30,14 @@ class ParamHandler(ApiHandler[ParamItemT]):
         """Is parameter group supported."""
         return self.vapix.params.get(self.parameter_group) is not None
 
-    def get_params(self) -> dict[str, ParamItemT]:
-        """Retrieve parameters from param_cgi class."""
-        if data := self.vapix.params.get(self.parameter_group):
-            return self.parameter_item.decode_to_dict([data])
-        return {}
-
     def update_params(self, obj_id: str) -> None:
         """Update parameter data.
 
         Callback from parameter handler subscription.
         """
-        self._items = self.get_params()
-        self.initialized = True
+        if data := self.vapix.params.get(self.parameter_group):
+            self._items = self.parameter_item.decode_to_dict([data])
+            self.initialized = True
 
     async def _update(self) -> None:
         """Refresh data."""

--- a/axis/vapix/interfaces/port_cgi.py
+++ b/axis/vapix/interfaces/port_cgi.py
@@ -34,7 +34,7 @@ class Ports(ApiHandler[IOPortParam]):
 
     def load_ports(self) -> None:
         """Load ports into class."""
-        self._items = self.process_ports()
+        self._items.update(self.process_ports())
 
     def process_ports(self) -> dict[str, IOPortParam]:
         """Process ports from I/O port handler."""

--- a/axis/vapix/vapix.py
+++ b/axis/vapix/vapix.py
@@ -233,7 +233,7 @@ class Vapix:
 
         if not user_groups and await self.user_groups.update():
             return
-        self.user_groups._items = user_groups
+        self.user_groups._items.update(user_groups)
 
     async def api_request(self, api_request: ApiRequest) -> bytes:
         """Make a request to the device."""

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -1,0 +1,84 @@
+"""Validate API handler and its subsription handling."""
+from unittest.mock import Mock
+
+from axis.vapix.interfaces.api_handler import SubscriptionHandler
+
+
+class ClassForTest(SubscriptionHandler):
+    """Class to test subscriptions."""
+
+
+def test_no_subscribers() -> None:
+    """Check data on no subscribers."""
+    test_class = ClassForTest()
+
+    assert len(test_class._subscribers) == 1
+
+    callback = Mock()
+    test_class.signal_subscribers("1")
+    callback.assert_not_called()
+
+
+def test_all_filter_subscribers() -> None:
+    """Validate signalling a ID all subscriber."""
+    test_class = ClassForTest()
+
+    assert len(test_class._subscribers) == 1
+    unsub = test_class.subscribe(callback := Mock())
+    assert len(test_class._subscribers) == 1
+
+    test_class.signal_subscribers("1")
+    callback.assert_called_once_with("1")
+
+    test_class.signal_subscribers("2")
+    callback.assert_called_with("2")
+
+    unsub()
+
+
+def test_id_1_filter_subscribers() -> None:
+    """Validate signalling one subscriber."""
+    test_class = ClassForTest()
+
+    assert len(test_class._subscribers) == 1
+    test_class.subscribe(callback := Mock(), "1")
+    assert len(test_class._subscribers) == 2
+
+    test_class.signal_subscribers("1")
+    callback.assert_called_once_with("1")
+
+    test_class.signal_subscribers("2")
+    callback.assert_called_once_with("1")
+
+
+def test_multiple_subscribers() -> None:
+    """Validate signalling multiple subscribers."""
+    test_class = ClassForTest()
+
+    assert len(test_class._subscribers) == 1
+    test_class.subscribe(callback := Mock(), "1")
+    assert len(test_class._subscribers) == 2
+    test_class.subscribe(callback2 := Mock())
+    assert len(test_class._subscribers) == 2
+
+    test_class.signal_subscribers("1")
+    callback.assert_called_with("1")
+
+    test_class.signal_subscribers("2")
+    callback2.assert_called_with("2")
+
+
+def test_unsub_missing_obj_id() -> None:
+    """Validate nothing breaks on unsub with missing object id."""
+    test_class = ClassForTest()
+    unsub = test_class.subscribe(Mock())
+    test_class._subscribers.clear()
+    unsub()
+
+
+def test_unsub_missing_subscription() -> None:
+    """Validate nothing breaks on unsub with missing subscription."""
+    test_class = ClassForTest()
+    unsub = test_class.subscribe(Mock())
+    test_class._subscribers["*"].clear()
+    unsub()

--- a/tests/test_param_cgi.py
+++ b/tests/test_param_cgi.py
@@ -24,15 +24,6 @@ async def test_parameter_group_enum():
     assert ParameterGroup("unsupported") is ParameterGroup.UNKNOWN
 
 
-async def test_param_unused_api_request(params: Params):
-    """Verify that you can list parameters."""
-    with pytest.raises(NotImplementedError):
-        await params._api_request()
-    with pytest.raises(NotImplementedError):
-        await params.brand_handler._api_request()
-    assert params.brand_handler.get_params() == {}
-
-
 @respx.mock
 async def test_params(params: Params):
     """Verify that you can list parameters."""

--- a/tests/test_param_cgi.py
+++ b/tests/test_param_cgi.py
@@ -50,14 +50,14 @@ async def test_params(params: Params):
     assert route.calls.last.request.method == "GET"
     assert route.calls.last.request.url.path == "/axis-cgi/param.cgi"
 
-    assert params.get_param(ParameterGroup.BRAND)
-    assert params.get_param(ParameterGroup.IMAGE)
-    assert params.get_param(ParameterGroup.INPUT)
-    assert params.get_param(ParameterGroup.OUTPUT)
-    assert params.get_param(ParameterGroup.IOPORT)
-    assert params.get_param(ParameterGroup.PROPERTIES)
-    assert params.get_param(ParameterGroup.PTZ)
-    assert params.get_param(ParameterGroup.STREAMPROFILE)
+    assert params.get(ParameterGroup.BRAND)
+    assert params.get(ParameterGroup.IMAGE)
+    assert params.get(ParameterGroup.INPUT)
+    assert params.get(ParameterGroup.OUTPUT)
+    assert params.get(ParameterGroup.IOPORT)
+    assert params.get(ParameterGroup.PROPERTIES)
+    assert params.get(ParameterGroup.PTZ)
+    assert params.get(ParameterGroup.STREAMPROFILE)
 
 
 async def test_params_empty_raw(params: Params):

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -119,7 +119,6 @@ async def test_initialize(vapix: Vapix):
     assert vapix.stream_profiles
     assert len(vapix.view_areas) == 0
 
-    assert vapix.params.brand_handler.get_params()["0"].brand == "AXIS"
     assert vapix.firmware_version == "9.80.1"
     assert vapix.product_number == "M1065-LW"
     assert vapix.product_type == "Network Camera"
@@ -230,7 +229,6 @@ async def test_initialize_param_cgi(vapix: Vapix):
     )
     await vapix.initialize_param_cgi()
 
-    assert vapix.params.brand_handler.get_params()["0"].brand == "AXIS"
     assert vapix.firmware_version == "9.10.1"
     assert vapix.product_number == "M1065-LW"
     assert vapix.product_type == "Network Camera"


### PR DESCRIPTION
This makes get_param and get_params functionality work directly with the ordinary get method