### PR TITLE
Handle light control error 1005: "No light hardware found"

### DIFF
--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -279,7 +279,7 @@ class GetLightInformationResponse(ApiResponse[dict[str, LightInformation]]):
             api_version=data["apiVersion"],
             context=data["context"],
             method=data["method"],
-            data=LightInformation.decode_to_dict(data["data"]["items"]),
+            data=LightInformation.decode_to_dict(data.get("data", {}).get("items", [])),
         )
 
 

--- a/tests/test_light_control.py
+++ b/tests/test_light_control.py
@@ -174,6 +174,24 @@ async def test_get_light_information(respx_mock, light_control: LightHandler):
     assert light.error_info == ""
 
 
+async def test_get_light_information_error(respx_mock, light_control: LightHandler):
+    """Test get light information API return error."""
+    respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
+        json={
+            "apiVersion": "1.1",
+            "context": "Axis library",
+            "method": "getLightInformation",
+            "error": {
+                "code": 1005,
+                "message": "No light hardware found, could not complete request.",
+            },
+        },
+    )
+
+    response = await light_control.get_light_information()
+    assert len(response) == 0
+
+
 async def test_activate_light(respx_mock, light_control):
     """Test activating light API."""
     route = respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(


### PR DESCRIPTION
Reported here https://github.com/home-assistant/core/issues/114033

Note: need to centralise error handling, this will not scale