### PR TITLE
Add authentication support for Companion cameras

### DIFF
--- a/axis/__main__.py
+++ b/axis/__main__.py
@@ -17,13 +17,18 @@ def event_handler(event: axis.models.event.Event) -> None:
 
 
 async def axis_device(
-    host: str, port: int, username: str, password: str
+    host: str, port: int, username: str, password: str, is_companion: bool = False
 ) -> axis.device.AxisDevice:
     """Create a Axis device."""
     session = AsyncClient(verify=False)  # noqa: S501
     device = axis.device.AxisDevice(
         axis.models.configuration.Configuration(
-            session, host, port=port, username=username, password=password
+            session,
+            host,
+            port=port,
+            username=username,
+            password=password,
+            is_companion=is_companion,
         )
     )
 

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -11,17 +11,11 @@ import httpx
 from ..errors import RequestError, raise_error
 from ..models.pwdgrp_cgi import SecondaryGroup
 from .api_discovery import ApiDiscoveryHandler
-from .applications import (
-    ApplicationsHandler,
-)
+from .applications import ApplicationsHandler
 from .applications.fence_guard import FenceGuardHandler
-from .applications.loitering_guard import (
-    LoiteringGuardHandler,
-)
+from .applications.loitering_guard import LoiteringGuardHandler
 from .applications.motion_guard import MotionGuardHandler
-from .applications.object_analytics import (
-    ObjectAnalyticsHandler,
-)
+from .applications.object_analytics import ObjectAnalyticsHandler
 from .applications.vmd4 import Vmd4Handler
 from .basic_device_info import BasicDeviceInfoHandler
 from .event_instances import EventInstanceHandler
@@ -242,13 +236,17 @@ class Vapix:
 
     async def api_request(self, api_request: ApiRequest) -> bytes:
         """Make a request to the device."""
+        # if is companion, join params with &Axis-Orig-Sw=true
+        params = api_request.params or {}
+        if self.device.config.is_companion:
+            params["Axis-Orig-Sw"] = "true"
         return await self.request(
             method=api_request.method,
             path=api_request.path,
             content=api_request.content,
             data=api_request.data,
             headers=api_request.headers,
-            params=api_request.params,
+            params=params,
         )
 
     async def request(

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -236,7 +236,6 @@ class Vapix:
 
     async def api_request(self, api_request: ApiRequest) -> bytes:
         """Make a request to the device."""
-        # if is companion, join params with &Axis-Orig-Sw=true
         params = api_request.params or {}
         if self.device.config.is_companion:
             params["Axis-Orig-Sw"] = "true"

--- a/axis/models/configuration.py
+++ b/axis/models/configuration.py
@@ -17,7 +17,7 @@ class Configuration:
     port: int = 80
     web_proto: str = "http"
     verify_ssl: bool = False
-    is_companion = False
+    is_companion: bool = False
 
     @property
     def url(self) -> str:

--- a/axis/models/configuration.py
+++ b/axis/models/configuration.py
@@ -17,6 +17,7 @@ class Configuration:
     port: int = 80
     web_proto: str = "http"
     verify_ssl: bool = False
+    is_companion = False
 
     @property
     def url(self) -> str:

--- a/axis/stream_manager.py
+++ b/axis/stream_manager.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 RTSP_URL = (
-    "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}"
+    "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}&Axis-Orig-Sw=true"
 )
 
 RETRY_TIMER = 15

--- a/axis/stream_manager.py
+++ b/axis/stream_manager.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 RTSP_URL = (
-    "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}&Axis-Orig-Sw=true"
+    "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}{axis_orig_sw}"
 )
 
 RETRY_TIMER = 15
@@ -43,6 +43,7 @@ class StreamManager:
             video=self.video_query,
             audio=self.audio_query,
             event=self.event_query,
+            axis_orig_sw="&Axis-Orig-Sw=true" if self.device.config.is_companion else "",
         )
         _LOGGER.debug(rtsp_url)
         return rtsp_url

--- a/axis/stream_manager.py
+++ b/axis/stream_manager.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-RTSP_URL = (
-    "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}{axis_orig_sw}"
-)
+RTSP_URL = "rtsp://{host}/axis-media/media.amp?video={video}&audio={audio}&event={event}{axis_orig_sw}"
 
 RETRY_TIMER = 15
 
@@ -43,7 +41,9 @@ class StreamManager:
             video=self.video_query,
             audio=self.audio_query,
             event=self.event_query,
-            axis_orig_sw="&Axis-Orig-Sw=true" if self.device.config.is_companion else "",
+            axis_orig_sw="&Axis-Orig-Sw=true"
+            if self.device.config.is_companion
+            else "",
         )
         _LOGGER.debug(rtsp_url)
         return rtsp_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,21 @@ async def axis_device(respx_mock: respx.router.MockRouter) -> AxisDevice:
     await session.aclose()
 
 
+@pytest.fixture
+async def axis_companion_device(respx_mock: respx.router.MockRouter) -> AxisDevice:
+    """Return the axis device.
+
+    Clean up sessions automatically at the end of each test.
+    """
+    respx_mock(base_url=f"http://{HOST}:80")
+    session = AsyncClient(verify=False)
+    axis_device = AxisDevice(
+        Configuration(session, HOST, username=USER, password=PASS, is_companion=True)
+    )
+    yield axis_device
+    await session.aclose()
+
+
 class TcpServerProtocol(asyncio.Protocol):
     """Simple socket server that responds with preset responses."""
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -28,6 +28,7 @@ def test_configuration():
     assert config.web_proto == "https"
     assert config.verify_ssl is True
     assert config.url == "https://192.168.0.1:443"
+    assert config.is_companion is False
 
 
 def test_minimal_configuration():
@@ -47,3 +48,4 @@ def test_minimal_configuration():
     assert config.web_proto == "http"
     assert config.verify_ssl is False
     assert config.url == "http://192.168.1.1:80"
+    assert config.is_companion is False

--- a/tests/test_stream_manager.py
+++ b/tests/test_stream_manager.py
@@ -20,6 +20,12 @@ def stream_manager(axis_device) -> StreamManager:
     return axis_device.stream
 
 
+@pytest.fixture
+def stream_manager_companion(axis_companion_device) -> StreamManager:
+    """Return the StreamManager mock object."""
+    return axis_companion_device.stream
+
+
 async def test_stream_url(stream_manager):
     """Verify stream url."""
     assert stream_manager.video_query == 0
@@ -35,6 +41,24 @@ async def test_stream_url(stream_manager):
     assert (
         stream_manager.stream_url
         == f"rtsp://{HOST}/axis-media/media.amp?video=0&audio=0&event=on"
+    )
+
+
+async def test_stream_url_companion(stream_manager_companion):
+    """Verify stream url."""
+    assert stream_manager_companion.video_query == 0
+    assert stream_manager_companion.audio_query == 0
+    assert stream_manager_companion.event_query == "off"
+    assert (
+        stream_manager_companion.stream_url
+        == f"rtsp://{HOST}/axis-media/media.amp?video=0&audio=0&event=off&Axis-Orig-Sw=true"
+    )
+
+    stream_manager_companion.event = True
+    assert stream_manager_companion.event_query == "on"
+    assert (
+        stream_manager_companion.stream_url
+        == f"rtsp://{HOST}/axis-media/media.amp?video=0&audio=0&event=on&Axis-Orig-Sw=true"
     )
 
 


### PR DESCRIPTION
Companion cameras require the `Axis-Orig-Sw=true` query string parameter in the rtsp url. Otherwise they respond with a 403.

I do not have the possibility with another camera model, so it's unclear if this affects other cameras. In that case AxisDevice might need some parameter to control this or the info could be derived from Vapix.