### PR TITLE
Improve mqtt_json_to_event annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       - id: mypy
         additional_dependencies: [
           "httpx==0.27.2",
+          "orjson==3.10.12",
           "packaging==24.2",
-          "types-orjson==3.6.2",
           "types-xmltodict==v0.14.0.20241009"
         ]
         exclude: ^tests/

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -25,7 +25,7 @@ from .api_handler import ApiHandler
 DEFAULT_TOPICS = ["//."]
 
 
-def mqtt_json_to_event(msg: bytes | str) -> dict[str, Any]:
+def mqtt_json_to_event(msg: bytes | bytearray | memoryview | str) -> dict[str, Any]:
     """Convert JSON message from MQTT to event format."""
     message = orjson.loads(msg)
     topic = message["topic"].replace("onvif", "tns1").replace("axis", "tnsaxis")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ requirements-test = [
     "pytest-cov==6.0.0",
     "respx==0.21.1",
     "ruff==0.8.2",
-    "types-orjson==3.6.2",
     "types-xmltodict==v0.14.0.20241009",
 ]
 requirements-dev = [


### PR DESCRIPTION
Mypy added the `--strict-bytes` flag today. https://github.com/python/mypy/pull/18263
With it enabled `bytearray` and `memoryview` are no longer subclasses of `bytes`.

Also removed `types-orjson` as it's outdated. `orjson` itself ships up-to date stubs.