### PR TITLE
Fix for non UTF-8 character in byte data #472

### DIFF
--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -3,6 +3,8 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+from chardet import detect
+
 from ...models.api_discovery import ApiId
 from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, params_to_dict
 from ..api_handler import ApiHandler
@@ -36,7 +38,8 @@ class Params(ApiHandler[Any]):
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
         """Fetch parameter data and convert it into a dictionary."""
         bytes_data = await self.vapix.api_request(ParamRequest(group))
-        return params_to_dict(bytes_data.decode()).get("root") or {}
+        encoding = detect(bytes_data)["encoding"] or "utf-8"
+        return params_to_dict(bytes_data.decode(encoding=encoding)).get("root") or {}
 
     async def _update(self, group: ParameterGroup | None = None) -> Sequence[str]:
         """Request parameter data and update items."""

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from chardet import detect
+from cchardet import detect
 
 from ...models.api_discovery import ApiId
 from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, params_to_dict

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -1,9 +1,19 @@
 """Axis Vapix parameter management."""
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
-from cchardet import detect
+if TYPE_CHECKING:
+
+    class _DetectResultType(TypedDict):
+        encoding: str
+        confidence: float
+
+    def detect(byte_str: bytes | bytearray) -> _DetectResultType:
+        """Typed interface for chardet detect method."""
+        ...
+else:
+    from cchardet import detect
 
 from ...models.api_discovery import ApiId
 from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, params_to_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.12.0"
 dependencies    = [
+    "chardet>=5.2.0",
     "httpx>=0.26",
     "orjson>3.9",
     "packaging>23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.12.0"
 dependencies    = [
-    "chardet>=5.2.0",
+    "faust-cchardet>=2.1.18",
     "httpx>=0.26",
     "orjson>3.9",
     "packaging>23",

--- a/tests/parameters/test_brand.py
+++ b/tests/parameters/test_brand.py
@@ -34,8 +34,8 @@ async def test_brand_handler(respx_mock, brand_handler: BrandParameterHandler):
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.Brand"},
     ).respond(
-        text=BRAND_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=BRAND_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not brand_handler.initialized
 
@@ -62,8 +62,8 @@ async def test_brand_handler_5_51(respx_mock, brand_handler: BrandParameterHandl
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.Brand"},
     ).respond(
-        text=BRAND_5_51_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=BRAND_5_51_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     await brand_handler.update()
 

--- a/tests/parameters/test_image.py
+++ b/tests/parameters/test_image.py
@@ -22,7 +22,7 @@ root.Image.TimeFormat=24
 root.Image.TimeResolution=1
 root.Image.TriggerDataEnabled=no
 root.Image.I0.Enabled=yes
-root.Image.I0.Name=View Area 1
+root.Image.I0.Name=Fußgängerüberweg
 root.Image.I0.Source=0
 root.Image.I0.Appearance.ColorEnabled=yes
 root.Image.I0.Appearance.Compression=30
@@ -231,8 +231,8 @@ async def test_image_handler(respx_mock, image_handler: ImageParameterHandler):
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.Image"},
     ).respond(
-        text=IMAGE_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=IMAGE_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not image_handler.initialized
 
@@ -245,7 +245,7 @@ async def test_image_handler(respx_mock, image_handler: ImageParameterHandler):
     assert image_handler.initialized
     image_0 = image_handler["0"]
     assert image_0.enabled is True
-    assert image_0.name == "View Area 1"
+    assert image_0.name == "Fußgängerüberweg"
     assert image_0.source == 0
     assert image_0.appearance == {
         "ColorEnabled": True,
@@ -382,6 +382,8 @@ async def test_limited_image_data(
     """
     respx_mock.post(
         "/axis-cgi/param.cgi", data={"action": "list", "group": "root.Image"}
-    ).respond(text=image_response, headers={"Content-Type": "text/plain"})
-
+    ).respond(
+        content=image_response.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
     await image_handler.update()

--- a/tests/parameters/test_io_port.py
+++ b/tests/parameters/test_io_port.py
@@ -35,8 +35,8 @@ async def test_io_port_handler(respx_mock, io_port_handler: IOPortParameterHandl
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.IOPort"},
     ).respond(
-        text=PORT_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PORT_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not io_port_handler.initialized
 

--- a/tests/parameters/test_param_cgi.py
+++ b/tests/parameters/test_param_cgi.py
@@ -43,8 +43,8 @@ async def test_param_handler(respx_mock, param_handler: Params):
         "/axis-cgi/param.cgi",
         data={"action": "list"},
     ).respond(
-        text=PARAM_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not param_handler.initialized
 
@@ -634,12 +634,12 @@ root.PTZ.Preset.P0.HomePosition=1
 root.PTZ.Preset.P0.ImageSource=0
 root.PTZ.Preset.P0.Name=
 root.PTZ.Preset.P0.Position.P1.Data=pan=0.000000:tilt=0.000000:zoom=1.000000
-root.PTZ.Preset.P0.Position.P1.Name=Home
+root.PTZ.Preset.P0.Position.P1.Name=Entrée
 root.PTZ.Preset.P1.HomePosition=1
 root.PTZ.Preset.P1.ImageSource=1
 root.PTZ.Preset.P1.Name=
 root.PTZ.Preset.P1.Position.P1.Data=pan=0.000000:tilt=0.000000:zoom=1.000000
-root.PTZ.Preset.P1.Position.P1.Name=Home
+root.PTZ.Preset.P1.Position.P1.Name=Haustür
 root.PTZ.PTZDriverStatuses.Driver1Status=3
 root.PTZ.PTZDriverStatuses.Driver2Status=3
 root.PTZ.Support.S1.AbsoluteBrightness=false

--- a/tests/parameters/test_properties.py
+++ b/tests/parameters/test_properties.py
@@ -192,8 +192,8 @@ async def test_property_handler(respx_mock, property_handler: PropertyParameterH
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.Properties"},
     ).respond(
-        text=PROPERTY_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PROPERTY_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not property_handler.initialized
     await property_handler.update()
@@ -258,6 +258,9 @@ async def test_mixed_properties(
     """
     respx_mock.post(
         "/axis-cgi/param.cgi", data={"action": "list", "group": "root.Properties"}
-    ).respond(text=property_response, headers={"Content-Type": "text/plain"})
+    ).respond(
+        content=property_response.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
 
     await property_handler.update()

--- a/tests/parameters/test_ptz.py
+++ b/tests/parameters/test_ptz.py
@@ -29,7 +29,7 @@ root.PTZ.Preset.P0.HomePosition=1
 root.PTZ.Preset.P0.ImageSource=0
 root.PTZ.Preset.P0.Name=
 root.PTZ.Preset.P0.Position.P1.Data=tilt=0.000000:focus=32766.000000:pan=0.000000:iris=32766.000000:zoom=1.000000
-root.PTZ.Preset.P0.Position.P1.Name=Home
+root.PTZ.Preset.P0.Position.P1.Name=Entrée
 root.PTZ.PTZDriverStatuses.Driver1Status=3
 root.PTZ.SerDriverStatuses.Ser1Status=3
 root.PTZ.Support.S1.AbsoluteBrightness=true
@@ -1600,8 +1600,8 @@ async def test_update_ptz(respx_mock, ptz_handler: PtzParameterHandler):
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.PTZ"},
     ).respond(
-        text=PTZ_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PTZ_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not ptz_handler.initialized
 
@@ -1710,6 +1710,9 @@ async def test_ptz_5_51(respx_mock, ptz_handler: PtzParameterHandler, ptz_respon
     """
     respx_mock.post(
         "/axis-cgi/param.cgi", data={"action": "list", "group": "root.PTZ"}
-    ).respond(text=ptz_response, headers={"Content-Type": "text/plain"})
+    ).respond(
+        content=ptz_response.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
 
     await ptz_handler.update()

--- a/tests/parameters/test_stream_profile.py
+++ b/tests/parameters/test_stream_profile.py
@@ -31,8 +31,8 @@ async def test_stream_profile_handler(
         "/axis-cgi/param.cgi",
         data={"action": "list", "group": "root.StreamProfile"},
     ).respond(
-        text=STREAM_PROFILE_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=STREAM_PROFILE_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     assert not stream_profile_handler.initialized
 

--- a/tests/test_port_cgi.py
+++ b/tests/test_port_cgi.py
@@ -20,7 +20,7 @@ def ports(axis_device) -> Ports:
 async def test_ports(respx_mock, ports: Ports) -> None:
     """Test that different types of ports work."""
     update_ports_route = respx_mock.post(f"http://{HOST}/axis-cgi/param.cgi").respond(
-        text="""root.Input.NbrOfInputs=3
+        content="""root.Input.NbrOfInputs=3
 root.IOPort.I0.Direction=input
 root.IOPort.I0.Usage=Button
 root.IOPort.I1.Configurable=no
@@ -44,8 +44,8 @@ root.IOPort.I3.Output.Mode=bistable
 root.IOPort.I3.Output.Name=Tampering
 root.IOPort.I3.Output.PulseTime=0
 root.Output.NbrOfOutputs=1
-""",
-        headers={"Content-Type": "text/plain"},
+""".encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
 
     await ports.update()
@@ -99,8 +99,8 @@ root.Output.NbrOfOutputs=1
 async def test_no_ports(respx_mock, ports: Ports) -> None:
     """Test that no ports also work."""
     route = respx_mock.post(f"http://{HOST}/axis-cgi/param.cgi").respond(
-        text="",
-        headers={"Content-Type": "text/plain"},
+        content="".encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
 
     await ports.update()

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -98,8 +98,10 @@ async def test_initialize(respx_mock, vapix: Vapix):
         }
     )
 
-    respx_mock.post("/axis-cgi/param.cgi").respond(text=PARAM_CGI_RESPONSE)
-
+    respx_mock.post("/axis-cgi/param.cgi").respond(
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
     respx_mock.post("/axis-cgi/applications/list.cgi").respond(
         text=APPLICATIONS_RESPONSE,
         headers={"Content-Type": "text/xml"},
@@ -225,8 +227,8 @@ async def test_initialize_api_discovery_unsupported(respx_mock, vapix: Vapix):
 async def test_initialize_param_cgi(respx_mock, vapix: Vapix):
     """Verify that you can list parameters."""
     respx_mock.post("/axis-cgi/param.cgi").respond(
-        text=PARAM_CGI_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
@@ -255,8 +257,8 @@ async def test_initialize_param_cgi_for_companion_device(
 ):
     """Verify that you can list parameters."""
     respx_mock.post("/axis-cgi/param.cgi").respond(
-        text=PARAM_CGI_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
@@ -283,9 +285,10 @@ async def test_initialize_param_cgi_for_companion_device(
 
 async def test_initialize_params_no_data(respx_mock, vapix: Vapix):
     """Verify that you can list parameters."""
-    param_route = respx_mock.post(
-        "/axis-cgi/param.cgi",
-    ).respond(text="")
+    param_route = respx_mock.post("/axis-cgi/param.cgi").respond(
+        content="".encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
     await vapix.initialize_param_cgi(preload_data=False)
 
     assert param_route.call_count == 4
@@ -294,8 +297,8 @@ async def test_initialize_params_no_data(respx_mock, vapix: Vapix):
 async def test_initialize_applications(respx_mock, vapix: Vapix):
     """Verify you can list and retrieve descriptions of applications."""
     respx_mock.post("/axis-cgi/param.cgi").respond(
-        text=PARAM_CGI_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
@@ -334,8 +337,8 @@ async def test_initialize_applications(respx_mock, vapix: Vapix):
 async def test_initialize_applications_unauthorized(respx_mock, vapix: Vapix, code):
     """Verify initialize applications doesnt break on too low credentials."""
     respx_mock.post("/axis-cgi/param.cgi").respond(
-        text=PARAM_CGI_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
@@ -351,8 +354,8 @@ async def test_initialize_applications_unauthorized(respx_mock, vapix: Vapix, co
 async def test_initialize_applications_not_running(respx_mock, vapix: Vapix):
     """Verify you can list and retrieve descriptions of applications."""
     respx_mock.post("/axis-cgi/param.cgi").respond(
-        text=PARAM_CGI_RESPONSE,
-        headers={"Content-Type": "text/plain"},
+        content=PARAM_CGI_RESPONSE.encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
     respx_mock.post("/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
@@ -389,10 +392,10 @@ async def test_initialize_event_instances(respx_mock, vapix: Vapix):
 
 async def test_applications_dont_load_without_params(respx_mock, vapix: Vapix):
     """Applications depends on param cgi to be loaded first."""
-    param_route = respx_mock.post(
-        "/axis-cgi/param.cgi",
-    ).respond(text="key=value")
-
+    param_route = respx_mock.post("/axis-cgi/param.cgi").respond(
+        content="key=value".encode("iso-8859-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
     applications_route = respx_mock.post("/axis-cgi/applications/list.cgi")
 
     await vapix.initialize_param_cgi(preload_data=False)


### PR DESCRIPTION
This is a proposed fix for #472 as discussed in https://github.com/home-assistant/core/issues/116223#issuecomment-2802955704

It uses python's chardet library to detect encoding from content and enable handling of non-UTF8 characters (byte value >= 128 basically).

Tested OK on my HomeAssistant Instance and P5512-E cameras.