### PR TITLE
Bump pytest-asyncio to 1.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       - id: mypy
         additional_dependencies: [
           "httpx==0.28.1",
-          "orjson==3.10.16",
-          "packaging==24.2",
+          "orjson==3.11.1",
+          "packaging==25.0",
           "types-xmltodict==v0.14.0.20241009"
         ]
         exclude: ^tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requirements-test = [
     "mypy==1.17.1",
     "pytest==8.4.1",
     "pytest-aiohttp==1.1.0",
-    "pytest-asyncio==0.26.0",
+    "pytest-asyncio==1.1.0",
     "pytest-cov==6.2.1",
     "respx==0.22.0",
     "ruff==0.11.11",

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -674,7 +674,7 @@ def test_session_generate_digest_auth(rtsp_client):
     )
 
 
-def test_session_generate_basic_auth(event_loop, rtsp_client):
+def test_session_generate_basic_auth(rtsp_client):
     """Verify generate basic auth method."""
     session = rtsp_client.session
     session.update('WWW-Authenticate: Basic realm="AXIS_ACCC8E012345"\r\n')


### PR DESCRIPTION
Replaces #634 as event_loop fixture was removed from pytest-asyncio https://github.com/pytest-dev/pytest-asyncio/pull/1106