### PR TITLE
Improve EventTopic normalization and log only truly unsupported events

### DIFF
--- a/axis/interfaces/event_manager.py
+++ b/axis/interfaces/event_manager.py
@@ -29,6 +29,7 @@ class EventManager:
     def __init__(self) -> None:
         """Ready information about events."""
         self._known_topics: set[str] = set()
+        self._unsupported_topics: set[str] = set()
         self._subscribers: dict[str, list[SubscriptionType]] = {ID_FILTER_ALL: []}
 
     def handler(self, data: bytes | dict[str, Any]) -> None:
@@ -37,7 +38,13 @@ class EventManager:
         if LOGGER.isEnabledFor(logging.DEBUG):
             LOGGER.debug(event)
 
-        if event.topic_base == EventTopic.UNKNOWN or event.topic in BLACK_LISTED_TOPICS:
+        if event.topic_base == EventTopic.UNKNOWN:
+            if event.topic not in self._unsupported_topics:
+                LOGGER.warning("Ignoring unsupported event topic %s", event.topic)
+                self._unsupported_topics.add(event.topic)
+            return
+
+        if event.topic in BLACK_LISTED_TOPICS:
             return
 
         known = (unique_topic := f"{event.topic}_{event.id}") not in self._known_topics

--- a/axis/models/event.py
+++ b/axis/models/event.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Self, cast
+from typing import Any, Self
 
 import xmltodict
 
@@ -192,16 +192,10 @@ class Event:
         event_type = data.get(EVENT_TYPE, "")
         value = data.get(EVENT_VALUE, "")
 
-        topic_base = cast(
-            "EventTopic",
-            EventTopic._value2member_map_.get(topic, EventTopic.UNKNOWN),
-        )
+        topic_base = EventTopic(topic)
         if topic_base is EventTopic.UNKNOWN:
             _topic_base, _, _source_idx = topic.rpartition("/")
-            topic_base = cast(
-                "EventTopic",
-                EventTopic._value2member_map_.get(_topic_base, EventTopic.UNKNOWN),
-            )
+            topic_base = EventTopic(_topic_base)
             if source_idx == "":
                 source_idx = _source_idx
 

--- a/axis/models/event.py
+++ b/axis/models/event.py
@@ -192,8 +192,7 @@ class Event:
         event_type = data.get(EVENT_TYPE, "")
         value = data.get(EVENT_VALUE, "")
 
-        topic_base = EventTopic(topic)
-        if topic_base is EventTopic.UNKNOWN:
+        if (topic_base := EventTopic(topic)) is EventTopic.UNKNOWN:
             _topic_base, _, _source_idx = topic.rpartition("/")
             topic_base = EventTopic(_topic_base)
             if source_idx == "":

--- a/axis/models/event.py
+++ b/axis/models/event.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import xmltodict
 
@@ -62,8 +62,6 @@ class EventTopic(enum.StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> EventTopic:
         """Set default enum member if an unknown value is provided."""
-        if LOGGER.isEnabledFor(logging.DEBUG):
-            LOGGER.warning("Unsupported topic %s", value)
         return EventTopic.UNKNOWN
 
 
@@ -194,9 +192,16 @@ class Event:
         event_type = data.get(EVENT_TYPE, "")
         value = data.get(EVENT_VALUE, "")
 
-        if (topic_base := EventTopic(topic)) is EventTopic.UNKNOWN:
+        topic_base = cast(
+            "EventTopic",
+            EventTopic._value2member_map_.get(topic, EventTopic.UNKNOWN),
+        )
+        if topic_base is EventTopic.UNKNOWN:
             _topic_base, _, _source_idx = topic.rpartition("/")
-            topic_base = EventTopic(_topic_base)
+            topic_base = cast(
+                "EventTopic",
+                EventTopic._value2member_map_.get(_topic_base, EventTopic.UNKNOWN),
+            )
             if source_idx == "":
                 source_idx = _source_idx
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from axis.models.event import Event, EventGroup, EventOperation
+from axis.models.event import Event, EventGroup, EventOperation, EventTopic
 
 from .event_fixtures import (
     AUDIO_INIT,
@@ -439,3 +439,21 @@ def test_decode_from_dict_type_aware_is_tripped(
     event = Event.decode(event_data)
 
     assert event.is_tripped is expected
+
+
+def test_decode_from_dict_resolves_topic_suffix_without_warning(caplog) -> None:
+    """Verify recoverable topics do not produce unsupported-topic warnings."""
+    event_data = {
+        "topic": "tnsaxis:CameraApplicationPlatform/VMD/Camera1Profile1",
+        "source": "",
+        "source_idx": "",
+        "type": "active",
+        "value": "0",
+    }
+
+    with caplog.at_level("WARNING"):
+        event = Event.decode(event_data)
+
+    assert event.topic_base == EventTopic.MOTION_DETECTION_4
+    assert event.id == "Camera1Profile1"
+    assert "Unsupported topic" not in caplog.text

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -3,6 +3,7 @@
 pytest --cov-report term-missing --cov=axis.event_stream tests/test_event_stream.py
 """
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
@@ -407,6 +408,24 @@ def test_unsupported_event(event_manager: EventManager, subscriber: Mock) -> Non
     """Verify that unsupported events aren't signalled to subscribers."""
     event_manager.handler(GLOBAL_SCENE_CHANGE)
     subscriber.assert_not_called()
+
+
+def test_unsupported_event_logs_once(
+    event_manager: EventManager, subscriber: Mock, caplog
+) -> None:
+    """Verify unsupported topics are logged once and then deduplicated."""
+    with caplog.at_level(logging.WARNING):
+        event_manager.handler(GLOBAL_SCENE_CHANGE)
+        event_manager.handler(GLOBAL_SCENE_CHANGE)
+
+    subscriber.assert_not_called()
+
+    warning_messages = [
+        record.message
+        for record in caplog.records
+        if "Ignoring unsupported event topic" in record.message
+    ]
+    assert len(warning_messages) == 1
 
 
 def test_initialize_event_twice(event_manager: EventManager, subscriber: Mock) -> None:


### PR DESCRIPTION
## Summary
This PR reduces noisy unsupported-topic logging and ensures warnings are emitted only when an event is actually unsupported and discarded.

## What changed
- Updated EventTopic resolution in decode flow to avoid constructor probing noise:
  - Use EventTopic value-map lookup for exact topic matches.
  - Apply suffix fallback (`topic.rpartition("/")`) and resolve base topic quietly.
- Made `EventTopic._missing_` return `UNKNOWN` without logging.
- Moved unsupported-topic warning to the authoritative discard point in `EventManager.handler`.
- Deduplicated unsupported-topic warnings so each unknown topic is logged once.

## Why
Previously, `EventTopic(topic)` could invoke `_missing_` during intermediate parsing paths, which could produce warning logs for topics that were still recoverable via suffix fallback. This PR avoids those false positives and logs only when the event is truly unsupported.

## Tests
Added/updated focused tests:
- recoverable topic suffixes do not log unsupported-topic warnings
- unsupported topics are logged once and deduplicated

Validated with:
- `pytest tests/test_event.py tests/test_event_stream.py`
- `ruff check` on changed files
- `mypy axis`

## Review notes
- This PR is ready for review.
- Please do not merge until you approve.