### PR TITLE
Remove EventOperation warning for missing/unknown operation

### DIFF
--- a/axis/models/event.py
+++ b/axis/models/event.py
@@ -2,12 +2,9 @@
 
 from dataclasses import dataclass
 import enum
-import logging
 from typing import Any, Self
 
 import xmltodict
-
-LOGGER = logging.getLogger(__name__)
 
 
 class EventGroup(enum.StrEnum):
@@ -33,8 +30,6 @@ class EventOperation(enum.StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> EventOperation:
         """Set default enum member if an unknown value is provided."""
-        if LOGGER.isEnabledFor(logging.DEBUG):
-            LOGGER.warning("Unsupported operation %s", value)
         return EventOperation.UNKNOWN
 
 


### PR DESCRIPTION
## Summary
- remove warning logging from `EventOperation._missing_`
- keep fallback behavior to `EventOperation.UNKNOWN`
- remove now-unused `logging` import and module logger from `axis/models/event.py`

## Why
`operation` is present in RTSP ONVIF event XML, but can be absent for other transports where operation is inferred later by `EventManager`. Logging each unknown/missing operation is unnecessary diagnostics noise.

## Validation
- `pytest`: `test_unknown_event_operation`, `test_mqtt_event` (passed)
- pre-commit checks run on commit:
  - ruff check
  - ruff format
  - mypy