### PR TITLE
Move mqtt_json_to_event into the MQTT model

### DIFF
--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -2,8 +2,6 @@
 
 from typing import Any
 
-import orjson
-
 from ..models.api_discovery import ApiId
 from ..models.mqtt import (
     API_VERSION,
@@ -23,35 +21,6 @@ from ..models.mqtt import (
 from .api_handler import ApiHandler, HandlerGroup
 
 DEFAULT_TOPICS = ["//."]
-
-
-def mqtt_json_to_event(msg: bytes | bytearray | memoryview | str) -> dict[str, Any]:
-    """Convert JSON message from MQTT to event format.
-
-    Returns None if required keys are missing.
-    """
-    message = orjson.loads(msg)
-    topic = source = source_idx = data_type = data_value = ""
-
-    if "topic" in message:
-        topic = message["topic"].replace("onvif", "tns1").replace("axis", "tnsaxis")
-
-    msg_message = message.get("message", {})
-    if isinstance(msg_message, dict):
-        if source_dict := msg_message.get("source"):
-            source, source_idx = next(iter(source_dict.items()))
-        if data_dict := msg_message.get("data"):
-            data_type, data_value = next(iter(data_dict.items()))
-            if "active" in data_dict:
-                data_type, data_value = "active", data_dict["active"]
-
-    return {
-        "topic": topic,
-        "source": source,
-        "source_idx": source_idx,
-        "type": data_type,
-        "value": data_value,
-    }
 
 
 class MqttClientHandler(ApiHandler[Any]):

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Literal, NotRequired, Self
+from typing import Any, Literal, NotRequired, Self
 
 import orjson
 from typing_extensions import TypedDict
@@ -126,6 +126,32 @@ class GetEventPublicationConfigResponseT(TypedDict):
     method: str
     data: EventPublicationConfigDataT
     error: NotRequired[ErrorDataT]
+
+
+def mqtt_json_to_event(msg: bytes | bytearray | memoryview | str) -> dict[str, Any]:
+    """Convert MQTT JSON payload into the internal event dict format."""
+    message = orjson.loads(msg)
+    topic = source = source_idx = data_type = data_value = ""
+
+    if "topic" in message:
+        topic = message["topic"].replace("onvif", "tns1").replace("axis", "tnsaxis")
+
+    msg_message = message.get("message", {})
+    if isinstance(msg_message, dict):
+        if source_dict := msg_message.get("source"):
+            source, source_idx = next(iter(source_dict.items()))
+        if data_dict := msg_message.get("data"):
+            data_type, data_value = next(iter(data_dict.items()))
+            if "active" in data_dict:
+                data_type, data_value = "active", data_dict["active"]
+
+    return {
+        "topic": topic,
+        "source": source,
+        "source_idx": source_idx,
+        "type": data_type,
+        "value": data_value,
+    }
 
 
 general_error_codes = {

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -3,17 +3,26 @@
 pytest --cov-report term-missing --cov=axis.mqtt tests/test_mqtt.py
 """
 
+from __future__ import annotations
+
 import json
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
-from axis.interfaces.mqtt import MqttClientHandler, mqtt_json_to_event
-from axis.models.mqtt import ClientConfig, Message, Server, ServerProtocol, Ssl
+from axis.models.mqtt import (
+    ClientConfig,
+    Message,
+    Server,
+    ServerProtocol,
+    Ssl,
+    mqtt_json_to_event,
+)
 
 if TYPE_CHECKING:
     from axis.device import AxisDevice
+    from axis.interfaces.mqtt import MqttClientHandler
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- move `mqtt_json_to_event` from `axis/interfaces/mqtt.py` into `axis/models/mqtt.py`
- update MQTT tests to import the helper from the model module

## Validation
- `uv run ruff check axis/models/mqtt.py axis/interfaces/mqtt.py tests/test_mqtt.py`
- `uv run pytest tests/test_mqtt.py`
- commit hooks: ruff check, ruff format, mypy