### PR TITLE
test: improve coverage for event models and mqtt

### DIFF
--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from axis.models.event import Event, EventOperation, EventTopic
+from axis.models.event import (
+    Event,
+    EventOperation,
+    EventTopic,
+    extract_name_value,
+    traverse,
+)
 
 from .event_fixtures import (
     AUDIO_INIT,
@@ -438,3 +444,45 @@ def test_decode_from_dict_resolves_topic_suffix_without_warning(caplog) -> None:
     assert event.topic_base == EventTopic.MOTION_DETECTION_4
     assert event.id == "Camera1Profile1"
     assert "Unsupported topic" not in caplog.text
+
+
+def test_traverse_non_dict_data():
+    """Test traverse function with non-dict data returns empty dict."""
+    # Passing non-dict should return empty dict
+    result = traverse(None, ("key",))
+    assert result == {}
+
+    result = traverse("not a dict", ("key",))
+    assert result == {}
+
+    result = traverse([], ("key",))
+    assert result == {}
+
+
+def test_extract_name_value_empty_list():
+    """Test extract_name_value with empty SimpleItem list."""
+    # Empty list should return empty strings
+    data = {"SimpleItem": []}
+    name, value = extract_name_value(data)
+    assert name == ""
+    assert value == ""
+
+
+def test_extract_name_value_with_prefer():
+    """Test extract_name_value with prefer parameter finds matching item."""
+    # Test with prefer parameter that matches an item
+    data = {
+        "SimpleItem": [
+            {"Name": "State", "Value": "0"},
+            {"Name": "active", "Value": "1"},
+            {"Name": "Other", "Value": "2"},
+        ]
+    }
+    name, value = extract_name_value(data, prefer="active")
+    assert name == "active"
+    assert value == "1"
+
+    # Test with prefer parameter that doesn't match (falls back to first item)
+    name, value = extract_name_value(data, prefer="nonexistent")
+    assert name == "State"
+    assert value == "0"

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -499,3 +499,39 @@ def test_subscription(event_manager: EventManager) -> None:
     # Validate no exception when unsubscribe with no object ID exist
     event_manager._subscribers.pop("Camera1Profile1")
     unsub_vmd4_c1p1()
+
+
+async def test_event_manager_unsubscribe_twice(event_manager: EventManager):
+    """Test calling unsubscribe twice does not raise exception."""
+    callback = Mock()
+
+    unsub = event_manager.subscribe(callback)
+    unsub()  # First unsubscribe
+    unsub()  # Second unsubscribe should not raise exception
+
+    # Test unsubscribe after subscription is manually removed from subscribers
+    unsub2 = event_manager.subscribe(callback, id_filter="test_id")
+    # Manually remove the subscription from the list to trigger the continue branch
+    if event_manager._subscribers["test_id"]:
+        event_manager._subscribers["test_id"].clear()
+    unsub2()  # Should not raise exception even though subscription not in list
+
+
+async def test_event_manager_blacklisted_topic(event_manager: EventManager):
+    """Test that blacklisted topics are filtered and don't trigger callbacks."""
+    callback = Mock()
+    event_manager.subscribe(callback)
+
+    # Send a blacklisted timer topic event
+    event_data = {
+        "topic": "tns1:RuleEngine/tnsaxis:VideoMotionDetection/timer",
+        "source": "channel",
+        "source_idx": "1",
+        "type": "Motion",
+        "value": "1",
+    }
+
+    event_manager.handler(event_data)
+
+    # Callback should NOT be called for blacklisted topics
+    callback.assert_not_called()

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -13,6 +13,7 @@ import pytest
 
 from axis.models.mqtt import (
     ClientConfig,
+    ClientConnectionState,
     Message,
     Server,
     ServerProtocol,
@@ -419,3 +420,13 @@ GET_CLIENT_STATUS_RESPONSE = {
         },
     },
 }
+
+
+def test_client_connection_state_missing():
+    """Test ClientConnectionState._missing_ returns DISCONNECTED for unknown values."""
+    # Test unknown value returns DISCONNECTED
+    result = ClientConnectionState._missing_("unknown_state")
+    assert result == ClientConnectionState.DISCONNECTED
+
+    result = ClientConnectionState._missing_("not connected")
+    assert result == ClientConnectionState.DISCONNECTED


### PR DESCRIPTION
## Summary
Improves test coverage for event models, MQTT module, and event manager to achieve 100% on all three target modules.

## Changes
- **axis/models/event.py** (98% → **100%**):
  - Added test for `traverse()` with non-dict input (returns empty dict)
  - Added tests for `extract_name_value()` with empty SimpleItem list
  - Added tests for `extract_name_value()` with prefer parameter

- **axis/models/mqtt.py** (99% → **100%**):
  - Added test for `ClientConnectionState._missing_()` fallback for unknown values

- **axis/interfaces/event_manager.py** (98% → **100%**):
  - Added tests for `EventManager.unsubscribe()` edge cases
  - Added test for blacklisted topics filtering

## Coverage Summary
| Module | Before | After | Change |
|--------|--------|-------|--------|
| axis/models/event.py | 98% | **100%** | ✅ |
| axis/models/mqtt.py | 99% | **100%** | ✅ |
| axis/interfaces/event_manager.py | 98% | **100%** | ✅ |
| axis/interfaces/vapix.py | 95% | **95%** | ✅ |
| **Overall** | **97.91%** | **98.01%** | ✅ |

## Test Results
✅ **395 tests passing** (all passing)
✅ **98.01% coverage** (exceeds 95% requirement)
✅ Uncovered statements reduced from 89 to 85

## Validation
✅ All checks passing:
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy axis`
- `uv run pytest` (395 passed)