### PR TITLE
refactor: remove HTTPSession type alias in configuration

### DIFF
--- a/axis/models/configuration.py
+++ b/axis/models/configuration.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aiohttp import ClientSession
 
-    type HTTPSession = ClientSession
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +46,7 @@ class Configuration:
     A port value of 0 means use the default port for the configured protocol.
     """
 
-    session: HTTPSession
+    session: ClientSession
     host: str
     _: KW_ONLY
     username: str


### PR DESCRIPTION
## Summary
- remove the  alias from 
- type  directly as 
- keep behavior unchanged

## Why
The project uses aiohttp as the only HTTP client, so the extra alias is unnecessary indirection.

## Validation
- pre-commit hooks passed on commit:
  - ruff check
  - ruff format
  - mypy
- previously validated in this workspace:
  - Success: no issues found in 75 source files
  - ============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/robertsv/Development/axis
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.1.0, asyncio-1.3.0, aiohttp-1.1.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 395 items

tests/applications/test_applications.py ....                             [  1%]
tests/applications/test_fence_guard.py ..                                [  1%]
tests/applications/test_loitering_guard.py ..                            [  2%]
tests/applications/test_motion_guard.py ..                               [  2%]
tests/applications/test_object_analytics.py ...                          [  3%]
tests/applications/test_vmd4.py ..                                       [  3%]
tests/parameters/test_brand.py ..                                        [  4%]
tests/parameters/test_image.py ....                                      [  5%]
tests/parameters/test_io_port.py ...                                     [  6%]
tests/parameters/test_param_cgi.py .....                                 [  7%]
tests/parameters/test_properties.py ...                                  [  8%]
tests/parameters/test_ptz.py .......                                     [  9%]
tests/parameters/test_stream_profile.py .                                [ 10%]
tests/test_api_discovery.py ....                                         [ 11%]
tests/test_api_handler.py .............                                  [ 14%]
tests/test_auth_scheme.py ....                                           [ 15%]
tests/test_basic_device_info.py ..                                       [ 15%]
tests/test_configuration.py ...............                              [ 19%]
tests/test_conftest.py ..................                                [ 24%]
tests/test_device.py .                                                   [ 24%]
tests/test_event.py .....................................                [ 33%]
tests/test_event_instances.py ......                                     [ 35%]
tests/test_event_stream.py ..........................                    [ 42%]
tests/test_http_client_compat.py ..........                              [ 44%]
tests/test_light_control.py ........................                     [ 50%]
tests/test_main_http_client.py ......                                    [ 52%]
tests/test_mqtt.py ............                                          [ 55%]
tests/test_pir_sensor_configuration.py ....                              [ 56%]
tests/test_port_cgi.py ........                                          [ 58%]
tests/test_port_management.py .....                                      [ 59%]
tests/test_ptz.py .............................................          [ 70%]
tests/test_pwdgrp_cgi.py ........                                        [ 72%]
tests/test_rtsp.py .............                                         [ 76%]
tests/test_stream_manager.py .................                           [ 80%]
tests/test_stream_profiles.py ...                                        [ 81%]
tests/test_user_groups.py .....                                          [ 82%]
tests/test_vapix.py .................................                    [ 90%]
tests/test_view_areas.py ...........                                     [ 93%]
tests/test_websocket.py .........................                        [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.14.2-final-0 _______________

Name                                                  Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------
axis/__init__.py                                          2      0   100%
axis/__main__.py                                         79     55    30%   22, 35-70, 84-117, 141-187
axis/device.py                                           12      0   100%
axis/errors.py                                           12      0   100%
axis/interfaces/__init__.py                               0      0   100%
axis/interfaces/aiohttp_digest.py                        95     19    80%   45, 93-95, 129, 133-134, 157, 179-180, 197, 245-266
axis/interfaces/api_discovery.py                         17      0   100%
axis/interfaces/api_handler.py                          117      0   100%
axis/interfaces/applications/__init__.py                  1      0   100%
axis/interfaces/applications/application_handler.py      20      0   100%
axis/interfaces/applications/applications.py             16      0   100%
axis/interfaces/applications/fence_guard.py               9      0   100%
axis/interfaces/applications/loitering_guard.py           9      0   100%
axis/interfaces/applications/motion_guard.py              9      0   100%
axis/interfaces/applications/object_analytics.py          9      0   100%
axis/interfaces/applications/vmd4.py                      9      0   100%
axis/interfaces/basic_device_info.py                     17      0   100%
axis/interfaces/event_instances.py                       10      0   100%
axis/interfaces/event_manager.py                         62      0   100%
axis/interfaces/light_control.py                         74      0   100%
axis/interfaces/mqtt.py                                  27      0   100%
axis/interfaces/parameters/__init__.py                    0      0   100%
axis/interfaces/parameters/brand.py                       6      0   100%
axis/interfaces/parameters/image.py                       6      0   100%
axis/interfaces/parameters/io_port.py                     6      0   100%
axis/interfaces/parameters/param_cgi.py                  35      0   100%
axis/interfaces/parameters/param_handler.py              16      0   100%
axis/interfaces/parameters/properties.py                  6      0   100%
axis/interfaces/parameters/ptz.py                         6      0   100%
axis/interfaces/parameters/stream_profile.py              6      0   100%
axis/interfaces/pir_sensor_configuration.py              26      0   100%
axis/interfaces/port_cgi.py                              25      0   100%
axis/interfaces/port_management.py                       23      0   100%
axis/interfaces/ptz.py                                   19      0   100%
axis/interfaces/pwdgrp_cgi.py                            19      0   100%
axis/interfaces/stream_profiles.py                       17      0   100%
axis/interfaces/user_groups.py                            9      0   100%
axis/interfaces/vapix.py                                239     11    95%   324-325, 332-336, 414, 437, 441-442
axis/interfaces/view_areas.py                            29      0   100%
axis/models/__init__.py                                   0      0   100%
axis/models/api.py                                       42      0   100%
axis/models/api_discovery.py                            144      0   100%
axis/models/applications/__init__.py                      0      0   100%
axis/models/applications/application.py                  53      0   100%
axis/models/applications/fence_guard.py                  43      0   100%
axis/models/applications/loitering_guard.py              43      0   100%
axis/models/applications/motion_guard.py                 43      0   100%
axis/models/applications/object_analytics.py             59      0   100%
axis/models/applications/vmd4.py                         42      0   100%
axis/models/basic_device_info.py                         51      0   100%
axis/models/configuration.py                             45      0   100%
axis/models/event.py                                    115      0   100%
axis/models/event_instance.py                            53      0   100%
axis/models/light_control.py                            498      0   100%
axis/models/mqtt.py                                     385      0   100%
axis/models/parameters/__init__.py                        0      0   100%
axis/models/parameters/brand.py                          17      0   100%
axis/models/parameters/image.py                          24      0   100%
axis/models/parameters/io_port.py                        37      0   100%
axis/models/parameters/param_cgi.py                      73      0   100%
axis/models/parameters/properties.py                     38      0   100%
axis/models/parameters/ptz.py                            56      0   100%
axis/models/parameters/stream_profile.py                 18      0   100%
axis/models/pir_sensor_configuration.py                  84      0   100%
axis/models/port_cgi.py                                  10      0   100%
axis/models/port_management.py                          109      0   100%
axis/models/ptz_cgi.py                                  183      0   100%
axis/models/pwdgrp_cgi.py                                87      0   100%
axis/models/stream_profile.py                            56      0   100%
axis/models/user_group.py                                21      0   100%
axis/models/view_area.py                                101      0   100%
axis/rtsp.py                                            316      0   100%
axis/stream_manager.py                                  116      0   100%
axis/websocket.py                                       206      0   100%
-----------------------------------------------------------------------------------
TOTAL                                                  4267     85    98%
Required test coverage of 95.0% reached. Total coverage: 98.01%
============================= 395 passed in 1.36s ============================== (395 passed)
