### PR TITLE
refactor: collapse duplicated request execution in vapix

### DIFF
--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -370,26 +370,7 @@ class Vapix:
         headers: dict[str, str] | None,
         params: dict[str, str] | None,
     ) -> tuple[int, dict[str, str], bytes]:
-        """Execute request and normalize responses."""
-        return await self._perform_aiohttp_request(
-            method=method,
-            url=url,
-            content=content,
-            data=data,
-            headers=headers,
-            params=params,
-        )
-
-    async def _perform_aiohttp_request(
-        self,
-        method: str,
-        url: str,
-        content: bytes | None,
-        data: dict[str, str] | None,
-        headers: dict[str, str] | None,
-        params: dict[str, str] | None,
-    ) -> tuple[int, dict[str, str], bytes]:
-        """Execute request with an aiohttp session."""
+        """Execute request with the configured HTTP session."""
         request_data: bytes | dict[str, str] | None = (
             content if content is not None else data
         )

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -58,7 +58,7 @@ class Vapix:
         self._aiohttp_digest_auth = AiohttpDigestAuth(device)
 
         if device.config.auth_scheme == AuthScheme.BASIC:
-            self.auth = self._aiohttp_basic_auth()
+            self.auth = self._basic_auth()
         else:
             self.auth = None
             self._aiohttp_digest_middleware = self._aiohttp_digest_middleware_obj()
@@ -337,7 +337,7 @@ class Vapix:
 
         if status_code >= 400:
             if self._should_retry_with_basic(response_headers, allow_auto_basic_retry):
-                self.auth = self._aiohttp_basic_auth()
+                self.auth = self._basic_auth()
                 self._aiohttp_digest_middleware = None
                 return await self._request(
                     method=method,
@@ -427,7 +427,7 @@ class Vapix:
             password=self.device.config.password,
         )
 
-    def _aiohttp_basic_auth(self) -> object:
+    def _basic_auth(self) -> object:
         """Create aiohttp basic auth object."""
         return aiohttp.BasicAuth(
             self.device.config.username, self.device.config.password

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
@@ -49,7 +49,7 @@ TIME_OUT = 15
 class Vapix:
     """Vapix parameter request."""
 
-    auth: object
+    auth: AiohttpBasicAuth | None
 
     def __init__(self, device: AxisDevice) -> None:
         """Store local reference to device config."""
@@ -404,7 +404,7 @@ class Vapix:
 
     def _aiohttp_auth(self) -> AiohttpBasicAuth | None:
         """Return auth cast for aiohttp requests."""
-        return cast("AiohttpBasicAuth | None", self.auth)
+        return self.auth
 
     def _aiohttp_middlewares(self) -> tuple[Any, ...] | None:
         """Return aiohttp middlewares used for auth challenges."""

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -325,11 +325,11 @@ class Vapix:
             raise RequestError(message) from errt
 
         except Exception as err:
-            if aiohttp is not None and isinstance(err, aiohttp.ClientConnectionError):
+            if isinstance(err, aiohttp.ClientConnectionError):
                 LOGGER.debug("%s", err)
                 message = f"Connection error: {err}"
                 raise RequestError(message) from err
-            if aiohttp is not None and isinstance(err, aiohttp.ClientError):
+            if isinstance(err, aiohttp.ClientError):
                 LOGGER.debug("%s", err)
                 message = f"Unknown error: {err}"
                 raise RequestError(message) from err

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -337,7 +337,7 @@ class Vapix:
 
         if status_code >= 400:
             if self._should_retry_with_basic(response_headers, allow_auto_basic_retry):
-                self.auth = self._basic_auth()
+                self.auth = self._aiohttp_basic_auth()
                 self._aiohttp_digest_middleware = None
                 return await self._request(
                     method=method,
@@ -426,10 +426,6 @@ class Vapix:
             login=self.device.config.username,
             password=self.device.config.password,
         )
-
-    def _basic_auth(self) -> object:
-        """Create basic auth object."""
-        return self._aiohttp_basic_auth()
 
     def _aiohttp_basic_auth(self) -> object:
         """Create aiohttp basic auth object."""

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -427,7 +427,7 @@ class Vapix:
             password=self.device.config.password,
         )
 
-    def _basic_auth(self) -> object:
+    def _basic_auth(self) -> AiohttpBasicAuth:
         """Create aiohttp basic auth object."""
         return aiohttp.BasicAuth(
             self.device.config.username, self.device.config.password

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -35,8 +35,6 @@ from .user_groups import UserGroups
 from .view_areas import ViewAreaHandler
 
 if TYPE_CHECKING:
-    from aiohttp import BasicAuth as AiohttpBasicAuth
-
     from ..device import AxisDevice
     from ..models.api import ApiRequest
     from ..models.stream_profile import StreamProfile
@@ -49,7 +47,7 @@ TIME_OUT = 15
 class Vapix:
     """Vapix parameter request."""
 
-    auth: AiohttpBasicAuth | None
+    auth: aiohttp.BasicAuth | None
 
     def __init__(self, device: AxisDevice) -> None:
         """Store local reference to device config."""
@@ -410,7 +408,7 @@ class Vapix:
             password=self.device.config.password,
         )
 
-    def _basic_auth(self) -> AiohttpBasicAuth:
+    def _basic_auth(self) -> aiohttp.BasicAuth:
         """Create aiohttp basic auth object."""
         return aiohttp.BasicAuth(
             self.device.config.username, self.device.config.password

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -35,7 +35,7 @@ from .user_groups import UserGroups
 from .view_areas import ViewAreaHandler
 
 if TYPE_CHECKING:
-    from aiohttp import BasicAuth as AiohttpBasicAuth, ClientSession
+    from aiohttp import BasicAuth as AiohttpBasicAuth
 
     from ..device import AxisDevice
     from ..models.api import ApiRequest
@@ -374,7 +374,7 @@ class Vapix:
         request_data: bytes | dict[str, str] | None = (
             content if content is not None else data
         )
-        session = self._aiohttp_session()
+        session = self.device.config.session
 
         if not self.auth and self.device.config.auth_scheme != AuthScheme.BASIC:
             return await self._aiohttp_digest_auth.perform_request(
@@ -394,10 +394,6 @@ class Vapix:
         async with session.request(method, url, **request_kwargs) as response:
             response_content = await response.read()
             return response.status, dict(response.headers), response_content
-
-    def _aiohttp_session(self) -> ClientSession:
-        """Return session cast to an aiohttp client."""
-        return self.device.config.session
 
     def _aiohttp_middlewares(self) -> tuple[Any, ...] | None:
         """Return aiohttp middlewares used for auth challenges."""

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -376,10 +376,7 @@ class Vapix:
         )
         session = self._aiohttp_session()
 
-        if (
-            not self._aiohttp_auth()
-            and self.device.config.auth_scheme != AuthScheme.BASIC
-        ):
+        if not self.auth and self.device.config.auth_scheme != AuthScheme.BASIC:
             return await self._aiohttp_digest_auth.perform_request(
                 session, method, url, request_data, headers, params
             )
@@ -388,7 +385,7 @@ class Vapix:
             "data": request_data,
             "headers": headers,
             "params": params,
-            "auth": self._aiohttp_auth(),
+            "auth": self.auth,
             "timeout": TIME_OUT,
         }
         if middlewares := self._aiohttp_middlewares():
@@ -401,10 +398,6 @@ class Vapix:
     def _aiohttp_session(self) -> ClientSession:
         """Return session cast to an aiohttp client."""
         return self.device.config.session
-
-    def _aiohttp_auth(self) -> AiohttpBasicAuth | None:
-        """Return auth cast for aiohttp requests."""
-        return self.auth
 
     def _aiohttp_middlewares(self) -> tuple[Any, ...] | None:
         """Return aiohttp middlewares used for auth challenges."""

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -388,18 +388,12 @@ class Vapix:
             "auth": self.auth,
             "timeout": TIME_OUT,
         }
-        if middlewares := self._aiohttp_middlewares():
-            request_kwargs["middlewares"] = middlewares
+        if self._aiohttp_digest_middleware is not None:
+            request_kwargs["middlewares"] = (self._aiohttp_digest_middleware,)
 
         async with session.request(method, url, **request_kwargs) as response:
             response_content = await response.read()
             return response.status, dict(response.headers), response_content
-
-    def _aiohttp_middlewares(self) -> tuple[Any, ...] | None:
-        """Return aiohttp middlewares used for auth challenges."""
-        if self._aiohttp_digest_middleware is None:
-            return None
-        return (self._aiohttp_digest_middleware,)
 
     def _aiohttp_digest_middleware_obj(self) -> Any | None:
         """Create aiohttp digest middleware when available and relevant."""

--- a/tests/test_http_client_compat.py
+++ b/tests/test_http_client_compat.py
@@ -93,7 +93,7 @@ async def test_aiohttp_client_session_auto_auth_fallback_to_basic(
     assert result == b"ok"
     assert calls == 2
     assert isinstance(axis_device.vapix.auth, aiohttp.BasicAuth)
-    assert axis_device.vapix._aiohttp_middlewares() is None
+    assert axis_device.vapix._aiohttp_digest_middleware is None
 
 
 @pytest.mark.skipif(
@@ -129,9 +129,7 @@ async def test_aiohttp_client_session_auto_initializes_digest_middleware(
     )
 
     assert axis_device.vapix.auth is None
-    middlewares = axis_device.vapix._aiohttp_middlewares()
-    assert middlewares is not None
-    assert len(middlewares) == 1
+    assert axis_device.vapix._aiohttp_digest_middleware is not None
 
 
 @pytest.mark.skipif(
@@ -167,9 +165,7 @@ async def test_aiohttp_client_session_digest_initializes_digest_middleware(
     )
 
     assert axis_device.vapix.auth is None
-    middlewares = axis_device.vapix._aiohttp_middlewares()
-    assert middlewares is not None
-    assert len(middlewares) == 1
+    assert axis_device.vapix._aiohttp_digest_middleware is not None
 
 
 async def test_aiohttp_digest_request_target_preencodes_query_params(


### PR DESCRIPTION
## Summary
- remove duplicated request execution path in Vapix
- inline the logic previously in _perform_aiohttp_request into _perform_request
- keep behavior unchanged while reducing aiohttp-specific naming noise

## Validation
- uv run mypy axis
- uv run pytest (395 passed, 98.01% coverage)
- commit hooks passed: ruff check, ruff format, mypy
