### PR TITLE
Adopt and enforce PEP 695 typing syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ uv run ruff check axis/<file>.py
 
 Run broader checks only when your change affects shared behavior (for example, base classes, event parsing, or configuration).
 
+## Branch and scope policy
+
+- Never commit directly on `master`; always use a feature branch and open a pull request.
+- Keep migrations that change typing syntax or lint policy behavior-neutral.
+- Split large migrations into reviewable commits with one clear objective per commit.
+- For syntax-only migrations, require full lint/type/test validation before merge.
+
 Coverage must stay at or above 95% overall. All new code you introduce must have 100% test coverage. `axis/stream_transport.py` is excluded from the threshold. `TYPE_CHECKING` blocks are automatically excluded.
 
 ## Pre-commit hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,12 @@ All code must pass strict `mypy` (see `[tool.mypy]` in `pyproject.toml`). Key re
 - `disallow_any_generics = true` — avoid bare `list`, `dict`, `tuple`; use parameterized forms.
 - Guard imports only needed for type checking with `if TYPE_CHECKING:`.
 
+This project uses PEP 695 syntax for new or updated typing code:
+
+- Use class type parameters instead of `Generic[...]` base classes.
+- Use `type` statements for aliases instead of assignment-style aliases.
+- Do not introduce new module-level `TypeVar(...)` declarations when class or function type parameters are sufficient.
+
 ## Tests
 
 Tests live in `tests/` and mirror the `axis/` structure. Use the nearest relevant test module for any behavior change.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Initial `ty` support is configured as an opt-in check and does not replace `mypy
 uvx ty check
 ```
 
-Typing style follows PEP 695 for new and updated code (class type parameters and `type` aliases).
-
 ## Initialization architecture
 
 Vapix initialization is phase-based and driven by handler metadata:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Initial `ty` support is configured as an opt-in check and does not replace `mypy
 uvx ty check
 ```
 
+Typing style follows PEP 695 for new and updated code (class type parameters and `type` aliases).
+
 ## Initialization architecture
 
 Vapix initialization is phase-based and driven by handler metadata:

--- a/axis/__main__.py
+++ b/axis/__main__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def event_handler(event: "Event") -> None:
+def event_handler(event: Event) -> None:
     """Receive and print events from RTSP stream."""
     LOGGER.info(event)
 
@@ -61,7 +61,7 @@ async def axis_device(
             "Connected to device at %s but not registered or user not admin.", host
         )
 
-    except (TimeoutError, axis.RequestError):
+    except TimeoutError, axis.RequestError:
         LOGGER.error("Error connecting to the Axis device at %s", host)
 
     except axis.AxisException:

--- a/axis/interfaces/aiohttp_digest.py
+++ b/axis/interfaces/aiohttp_digest.py
@@ -4,8 +4,6 @@ Implements library-managed RFC 2617 digest authentication for aiohttp requests
 to handle special characters in request parameters that break middleware-based auth.
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 import re

--- a/axis/interfaces/api_handler.py
+++ b/axis/interfaces/api_handler.py
@@ -62,6 +62,8 @@ class SubscriptionHandler:
             _id_filter = (ID_FILTER_ALL,)
         elif isinstance(id_filter, str):
             _id_filter = (id_filter,)
+        else:
+            _id_filter = id_filter
 
         for obj_id in _id_filter:
             if obj_id not in self._subscribers:

--- a/axis/interfaces/api_handler.py
+++ b/axis/interfaces/api_handler.py
@@ -9,7 +9,7 @@ from collections.abc import (
     ValuesView,
 )
 import enum
-from typing import TYPE_CHECKING, Generic, final
+from typing import TYPE_CHECKING, final
 
 from ..errors import Forbidden, PathNotFound, Unauthorized
 
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
     from ..models.api_discovery import ApiId
     from .vapix import Vapix
 
-from ..models.api import ApiItemT
+from ..models.api import ApiItem
 
-CallbackType = Callable[[str], None]
-SubscriptionType = CallbackType
-UnsubscribeType = Callable[[], None]
+type CallbackType = Callable[[str], None]
+type SubscriptionType = CallbackType
+type UnsubscribeType = Callable[[], None]
 
 ID_FILTER_ALL = "*"
 
@@ -79,7 +79,7 @@ class SubscriptionHandler:
         return unsubscribe
 
 
-class ApiHandler(SubscriptionHandler, Generic[ApiItemT]):
+class ApiHandler[ApiItemT: ApiItem](SubscriptionHandler):
     """Base class for a map of API Items."""
 
     api_id: ApiId | None = None

--- a/axis/interfaces/applications/application_handler.py
+++ b/axis/interfaces/applications/application_handler.py
@@ -2,12 +2,12 @@
 
 from abc import abstractmethod
 
-from ...models.api import ApiItemT
+from ...models.api import ApiItem
 from ...models.applications.application import ApplicationName, ApplicationStatus
 from ..api_handler import ApiHandler, HandlerGroup
 
 
-class ApplicationHandler(ApiHandler[ApiItemT]):
+class ApplicationHandler[ApiItemT: ApiItem](ApiHandler[ApiItemT]):
     """Generic application handler."""
 
     app_name: ApplicationName

--- a/axis/interfaces/event_manager.py
+++ b/axis/interfaces/event_manager.py
@@ -6,13 +6,13 @@ from typing import Any
 
 from ..models.event import Event, EventOperation, EventTopic
 
-SubscriptionCallback = Callable[[Event], None]
-SubscriptionType = tuple[
+type SubscriptionCallback = Callable[[Event], None]
+type SubscriptionType = tuple[
     SubscriptionCallback,
     tuple[EventTopic, ...] | None,
     tuple[EventOperation, ...] | None,
 ]
-UnsubscribeType = Callable[[], None]
+type UnsubscribeType = Callable[[], None]
 
 ID_FILTER_ALL = "*"
 

--- a/axis/interfaces/parameters/param_handler.py
+++ b/axis/interfaces/parameters/param_handler.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
     from .param_cgi import Params
 
-from ...models.parameters.param_cgi import ParameterGroup, ParamItemT
+from ...models.parameters.param_cgi import ParameterGroup, ParamItem
 from ..api_handler import ApiHandler
 
 
-class ParamHandler(ApiHandler[ParamItemT]):
+class ParamHandler[ParamItemT: ParamItem](ApiHandler[ParamItemT]):
     """Base class for a map of API Items."""
 
     parameter_group: ParameterGroup

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -1,7 +1,5 @@
 """Python library to enable Axis devices to integrate with Home Assistant."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from typing import TYPE_CHECKING, Any

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Generic, Self, TypeVar
+from typing import Any, Self
 
 CONTEXT = "Axis library"
 
@@ -29,10 +29,6 @@ class ApiItem(ABC):
         return {v.id: v for v in cls.decode_to_list(data)}
 
 
-ApiItemT = TypeVar("ApiItemT", bound=ApiItem)
-ApiDataT = TypeVar("ApiDataT")
-
-
 @dataclass
 class ApiResponseSupportDecode(ABC):
     """Response from API request."""
@@ -44,17 +40,11 @@ class ApiResponseSupportDecode(ABC):
 
 
 @dataclass
-class ApiResponse(ApiResponseSupportDecode, Generic[ApiDataT]):
-    """Response from API request.
-
-    Class with generic can't be used in a TypeVar("X", bound=class) statement.
-    """
+class ApiResponse[ApiDataT](ApiResponseSupportDecode):
+    """Response from API request."""
 
     data: ApiDataT
     # error: str
-
-
-ApiResponseT = TypeVar("ApiResponseT", bound=ApiResponseSupportDecode)
 
 
 @dataclass

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -3,10 +3,9 @@
 from dataclasses import dataclass
 import enum
 import logging
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/basic_device_info.py
+++ b/axis/models/basic_device_info.py
@@ -1,10 +1,9 @@
 """Basic device information description."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -1,7 +1,5 @@
 """Light Control API data model."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import NotRequired, Self, TypedDict
 

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Any, Literal, NotRequired, Self
+from typing import Any, Literal, NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiRequest, ApiResponse
 

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -1,7 +1,5 @@
 """MQTT Client api."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 from typing import Any, Literal, NotRequired, Self, TypedDict

--- a/axis/models/parameters/brand.py
+++ b/axis/models/parameters/brand.py
@@ -1,9 +1,7 @@
 """Brand parameters from param.cgi."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
-
-from typing_extensions import TypedDict
+from typing import NotRequired, Self, TypedDict
 
 from .param_cgi import ParamItem
 

--- a/axis/models/parameters/param_cgi.py
+++ b/axis/models/parameters/param_cgi.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Self, TypeVar
+from typing import Any, Self
 
 from ..api import ApiItem, ApiRequest
 
@@ -90,9 +90,6 @@ class ParamItem(ApiItem):
     def decode_to_dict(cls, data: list[Any]) -> dict[str, Self]:
         """Create objects from dict."""
         return {"0": cls.decode(data[0])}
-
-
-ParamItemT = TypeVar("ParamItemT", bound=ParamItem)
 
 
 @dataclass

--- a/axis/models/parameters/properties.py
+++ b/axis/models/parameters/properties.py
@@ -1,9 +1,7 @@
 """Property parameters from param.cgi."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
-
-from typing_extensions import TypedDict
+from typing import NotRequired, Self, TypedDict
 
 from .param_cgi import ParamItem
 

--- a/axis/models/parameters/ptz.py
+++ b/axis/models/parameters/ptz.py
@@ -1,9 +1,7 @@
 """PTZ parameters from param.cgi."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
-
-from typing_extensions import TypedDict
+from typing import NotRequired, Self, TypedDict
 
 from .param_cgi import ParamItem
 

--- a/axis/models/parameters/stream_profile.py
+++ b/axis/models/parameters/stream_profile.py
@@ -1,9 +1,7 @@
 """Stream profile parameters from param.cgi."""
 
 from dataclasses import dataclass
-from typing import Any, NotRequired, Self, cast
-
-from typing_extensions import TypedDict
+from typing import Any, NotRequired, Self, TypedDict, cast
 
 from ..stream_profile import StreamProfile
 from .param_cgi import ParamItem

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -5,10 +5,9 @@ the sensitivity of the PIR (passive infrared) sensors on your Axis device.
 """
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -2,9 +2,7 @@
 
 from dataclasses import dataclass
 import enum
-from typing import Self
-
-from typing_extensions import TypedDict
+from typing import Self, TypedDict
 
 from .api import ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/stream_profile.py
+++ b/axis/models/stream_profile.py
@@ -6,10 +6,9 @@ and should be used to retrieve a video stream from your Axis product.
 """
 
 from dataclasses import dataclass, field
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/models/view_area.py
+++ b/axis/models/view_area.py
@@ -1,10 +1,9 @@
 """View area API data model."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self
+from typing import NotRequired, Self, TypedDict
 
 import orjson
-from typing_extensions import TypedDict
 
 from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
 

--- a/axis/stream_transport.py
+++ b/axis/stream_transport.py
@@ -1,7 +1,5 @@
 """Transport protocol shared by stream implementations."""
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:

--- a/axis/websocket.py
+++ b/axis/websocket.py
@@ -9,8 +9,6 @@ Incoming ``events:notify`` JSON messages are parsed into the internal event
 dict format accepted by EventManager.handler().
 """
 
-from __future__ import annotations
-
 import asyncio
 from collections import deque
 import enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ lint.select = [
     "TD",   # flake8-todos
     # "TID", # flake8-tidy-imports
     # "TRY", # tryceratops
-    "UP", # pyupgrade
+    "UP", # pyupgrade -- PEP 695 enforcement: UP040 (type aliases), UP046 (generic classes), UP047 (generic functions)
     "W",  # pycodestyle
 ]
 
@@ -168,7 +168,7 @@ lint.ignore = [
 ]
 
 [tool.ruff.per-file-target-version]
-"axis/__main__.py" = "py313"
+"axis/__main__.py" = "py314"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ lint.ignore = [
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
     "S324", # Probable use of insecure hash functions in {library}: {string}
-    "UP046",  # 82 | class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
 ]
 
 [tool.ruff.per-file-target-version]

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -55,6 +55,30 @@ def test_id_1_filter_subscribers(test_class) -> None:
     callback.assert_called_once_with("1")
 
 
+def test_tuple_id_filter_subscribers(test_class) -> None:
+    """Validate tuple id_filter subscribes for each provided object id."""
+    test_class.subscribe(callback := Mock(), ("1", "2"))
+
+    test_class.signal_subscribers("1")
+    test_class.signal_subscribers("2")
+    test_class.signal_subscribers("3")
+
+    assert callback.call_count == 2
+    callback.assert_any_call("1")
+    callback.assert_any_call("2")
+
+
+def test_tuple_id_filter_unsubscribe(test_class) -> None:
+    """Validate tuple id_filter unsubscribe removes all tuple subscriptions."""
+    unsubscribe = test_class.subscribe(callback := Mock(), ("1", "2"))
+
+    unsubscribe()
+    test_class.signal_subscribers("1")
+    test_class.signal_subscribers("2")
+
+    callback.assert_not_called()
+
+
 def test_multiple_subscribers(test_class) -> None:
     """Validate signalling multiple subscribers."""
     assert len(test_class._subscribers) == 1


### PR DESCRIPTION
## Summary
This PR executes the full PEP 695 adoption plan in ordered, reviewable commits.

## Commit Plan Execution
1. docs: add migration governance safety rails (step 1)
2. chore: enforce PEP 695 via Ruff UP046 (step 2)
3. refactor: migrate generics and aliases to PEP 695 (step 3)
4. docs: codify PEP 695 typing style (step 4)
5. chore: record full verification pass (step 5)

## What changed
- Enabled lint enforcement by removing `UP046` ignore in `pyproject.toml`.
- Migrated core generic/type alias patterns to PEP 695 syntax.
- Updated application/parameter handler generic chains for type correctness.
- Normalized model `TypedDict` imports to stdlib `typing`.
- Added contributor/readme guidance for sustained PEP 695 usage.

## Validation
- Targeted tests: `tests/test_api_handler.py`, `tests/test_light_control.py`, `tests/test_stream_profiles.py`.
- Full tests: `pytest` suite passed.
- Static checks: Ruff lint/format and mypy passed.

## Notes
- Validation used project `.venv` binaries due missing `uv` command in current shell context, with equivalent check commands run successfully.