### PR TITLE
Feat/typed api request response

### DIFF
--- a/axis/interfaces/api_discovery.py
+++ b/axis/interfaces/api_discovery.py
@@ -33,11 +33,14 @@ class ApiDiscoveryHandler(ApiHandler[Api]):
 
     async def get_api_list(self) -> dict[str, Api]:
         """List all APIs registered on API Discovery service."""
-        bytes_data = await self.vapix.api_request(ListApisRequest())
-        return GetAllApisResponse.decode(bytes_data).data
+        response: GetAllApisResponse = await self.vapix.api_request_typed(
+            ListApisRequest()
+        )
+        return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/applications.py
+++ b/axis/interfaces/applications/applications.py
@@ -36,6 +36,7 @@ class ApplicationsHandler(ApiHandler[Application]):
 
     async def list_applications(self) -> dict[str, Application]:
         """List all APIs registered on API Discovery service."""
-        bytes_data = await self.vapix.api_request(ListApplicationsRequest())
-        response = ListApplicationsResponse.decode(bytes_data)
+        response: ListApplicationsResponse = await self.vapix.api_request_typed(
+            ListApplicationsRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/fence_guard.py
+++ b/axis/interfaces/applications/fence_guard.py
@@ -22,6 +22,7 @@ class FenceGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        bytes_data = await self.vapix.api_request(GetConfigurationRequest())
-        response = GetConfigurationResponse.decode(bytes_data)
+        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+            GetConfigurationRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/loitering_guard.py
+++ b/axis/interfaces/applications/loitering_guard.py
@@ -20,6 +20,7 @@ class LoiteringGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        bytes_data = await self.vapix.api_request(GetConfigurationRequest())
-        response = GetConfigurationResponse.decode(bytes_data)
+        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+            GetConfigurationRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/motion_guard.py
+++ b/axis/interfaces/applications/motion_guard.py
@@ -21,6 +21,7 @@ class MotionGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        bytes_data = await self.vapix.api_request(GetConfigurationRequest())
-        response = GetConfigurationResponse.decode(bytes_data)
+        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+            GetConfigurationRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/object_analytics.py
+++ b/axis/interfaces/applications/object_analytics.py
@@ -19,6 +19,7 @@ class ObjectAnalyticsHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of object analytics application."""
-        bytes_data = await self.vapix.api_request(GetConfigurationRequest())
-        response = GetConfigurationResponse.decode(bytes_data)
+        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+            GetConfigurationRequest()
+        )
         return response.data

--- a/axis/interfaces/applications/vmd4.py
+++ b/axis/interfaces/applications/vmd4.py
@@ -16,6 +16,7 @@ class Vmd4Handler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        bytes_data = await self.vapix.api_request(GetConfigurationRequest())
-        response = GetConfigurationResponse.decode(bytes_data)
+        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+            GetConfigurationRequest()
+        )
         return response.data

--- a/axis/interfaces/basic_device_info.py
+++ b/axis/interfaces/basic_device_info.py
@@ -30,14 +30,14 @@ class BasicDeviceInfoHandler(ApiHandler[DeviceInformation]):
 
     async def get_all_properties(self) -> dict[str, DeviceInformation]:
         """List all properties of basic device info."""
-        bytes_data = await self.vapix.api_request(
+        response: GetAllPropertiesResponse = await self.vapix.api_request_typed(
             GetAllPropertiesRequest(self.api_version)
         )
-        response = GetAllPropertiesResponse.decode(bytes_data)
         return {"0": response.data}
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
         return response.data

--- a/axis/interfaces/event_instances.py
+++ b/axis/interfaces/event_instances.py
@@ -23,8 +23,9 @@ class EventInstanceHandler(ApiHandler[EventInstance]):
 
     async def get_event_instances(self) -> dict[str, EventInstance]:
         """List all event instances."""
-        bytes_data = await self.vapix.api_request(ListEventInstancesRequest())
-        response = ListEventInstancesResponse.decode(bytes_data)
+        response: ListEventInstancesResponse = await self.vapix.api_request_typed(
+            ListEventInstancesRequest()
+        )
         return response.data
 
     def get_expected_events_per_topic(

--- a/axis/interfaces/light_control.py
+++ b/axis/interfaces/light_control.py
@@ -77,17 +77,17 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_information(self) -> dict[str, LightInformation]:
         """List the light control information."""
-        bytes_data = await self.vapix.api_request(
+        response: GetLightInformationResponse = await self.vapix.api_request_typed(
             GetLightInformationRequest(api_version=self.api_version)
         )
-        return GetLightInformationResponse.decode(bytes_data).data
+        return response.data
 
     async def get_service_capabilities(self) -> ServiceCapabilities:
         """List the light control information."""
-        bytes_data = await self.vapix.api_request(
+        response: GetServiceCapabilitiesResponse = await self.vapix.api_request_typed(
             GetServiceCapabilitiesRequest(api_version=self.api_version)
         )
-        return GetServiceCapabilitiesResponse.decode(bytes_data).data
+        return response.data
 
     async def activate_light(self, light_id: str) -> None:
         """Activate the light."""
@@ -115,10 +115,10 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_status(self, light_id: str) -> bool:
         """Get light status if its on or off."""
-        bytes_data = await self.vapix.api_request(
+        response: GetLightStatusResponse = await self.vapix.api_request_typed(
             GetLightStatusRequest(api_version=self.api_version, light_id=light_id)
         )
-        return GetLightStatusResponse.decode(bytes_data).data
+        return response.data
 
     async def set_automatic_intensity_mode(self, light_id: str, enabled: bool) -> None:
         """Enable the automatic light intensity control."""
@@ -132,10 +132,10 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_intensity(self, light_id: str) -> Range:
         """Get valid intensity range for light."""
-        bytes_data = await self.vapix.api_request(
+        response: GetValidIntensityResponse = await self.vapix.api_request_typed(
             GetValidIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
-        return GetValidIntensityResponse.decode(bytes_data).data
+        return response.data
 
     async def set_manual_intensity(self, light_id: str, intensity: int) -> None:
         """Manually sets the intensity."""
@@ -149,10 +149,10 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_intensity(self, light_id: str) -> int:
         """Enable the automatic light intensity control."""
-        bytes_data = await self.vapix.api_request(
+        response: GetManualIntensityResponse = await self.vapix.api_request_typed(
             GetManualIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
-        return GetManualIntensityResponse.decode(bytes_data).data
+        return response.data
 
     async def set_individual_intensity(
         self, light_id: str, led_id: int, intensity: int
@@ -169,21 +169,21 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_individual_intensity(self, light_id: str, led_id: int) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        bytes_data = await self.vapix.api_request(
+        response: GetIndividualIntensityResponse = await self.vapix.api_request_typed(
             GetIndividualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
                 led_id=led_id,
             )
         )
-        return GetIndividualIntensityResponse.decode(bytes_data).data
+        return response.data
 
     async def get_current_intensity(self, light_id: str) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        bytes_data = await self.vapix.api_request(
+        response: GetCurrentIntensityResponse = await self.vapix.api_request_typed(
             GetCurrentIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
-        return GetCurrentIntensityResponse.decode(bytes_data).data
+        return response.data
 
     async def set_automatic_angle_of_illumination_mode(
         self, light_id: str, enabled: bool
@@ -203,12 +203,14 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_angle_of_illumination(self, light_id: str) -> list[Range]:
         """List the valid angle of illumination values."""
-        bytes_data = await self.vapix.api_request(
-            GetValidAngleOfIlluminationRequest(
-                api_version=self.api_version, light_id=light_id
+        response: GetValidAngleOfIlluminationResponse = (
+            await self.vapix.api_request_typed(
+                GetValidAngleOfIlluminationRequest(
+                    api_version=self.api_version, light_id=light_id
+                )
             )
         )
-        return GetValidAngleOfIlluminationResponse.decode(bytes_data).data
+        return response.data
 
     async def set_manual_angle_of_illumination(
         self, light_id: str, angle_of_illumination: int
@@ -228,21 +230,25 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_angle_of_illumination(self, light_id: str) -> int:
         """Get the angle of illumination."""
-        bytes_data = await self.vapix.api_request(
-            GetManualAngleOfIlluminationRequest(
-                api_version=self.api_version, light_id=light_id
+        response: GetManualAngleOfIlluminationResponse = (
+            await self.vapix.api_request_typed(
+                GetManualAngleOfIlluminationRequest(
+                    api_version=self.api_version, light_id=light_id
+                )
             )
         )
-        return GetManualAngleOfIlluminationResponse.decode(bytes_data).data
+        return response.data
 
     async def get_current_angle_of_illumination(self, light_id: str) -> int:
         """Receive the current angle of illumination."""
-        bytes_data = await self.vapix.api_request(
-            GetCurrentAngleOfIlluminationRequest(
-                api_version=self.api_version, light_id=light_id
+        response: GetCurrentAngleOfIlluminationResponse = (
+            await self.vapix.api_request_typed(
+                GetCurrentAngleOfIlluminationRequest(
+                    api_version=self.api_version, light_id=light_id
+                )
             )
         )
-        return GetCurrentAngleOfIlluminationResponse.decode(bytes_data).data
+        return response.data
 
     async def set_light_synchronization_day_night_mode(
         self, light_id: str, enabled: bool
@@ -258,14 +264,18 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_synchronization_day_night_mode(self, light_id: str) -> bool:
         """Check if the automatic synchronization is enabled with the day/night mode."""
-        bytes_data = await self.vapix.api_request(
-            GetLightSynchronizeDayNightModeRequest(
-                api_version=self.api_version, light_id=light_id
+        response: GetLightSynchronizeDayNightModeResponse = (
+            await self.vapix.api_request_typed(
+                GetLightSynchronizeDayNightModeRequest(
+                    api_version=self.api_version, light_id=light_id
+                )
             )
         )
-        return GetLightSynchronizeDayNightModeResponse.decode(bytes_data).data
+        return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        return GetSupportedVersionsResponse.decode(bytes_data).data
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
+        return response.data

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -52,18 +52,18 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def get_client_status(self) -> ClientConfigStatus:
         """Get MQTT Client status."""
-        bytes_data = await self.vapix.api_request(
+        response: GetClientStatusResponse = await self.vapix.api_request_typed(
             GetClientStatusRequest(api_version=self.api_version)
         )
-        response = GetClientStatusResponse.decode(bytes_data)
         return response.data
 
     async def get_event_publication_config(self) -> EventPublicationConfig:
         """Get MQTT Client event publication config."""
-        bytes_data = await self.vapix.api_request(
-            GetEventPublicationConfigRequest(api_version=self.api_version)
+        response: GetEventPublicationConfigResponse = (
+            await self.vapix.api_request_typed(
+                GetEventPublicationConfigRequest(api_version=self.api_version)
+            )
         )
-        response = GetEventPublicationConfigResponse.decode(bytes_data)
         return response.data
 
     async def configure_event_publication(

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -1,22 +1,12 @@
 """Axis Vapix parameter management."""
 
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    class _DetectResultType(TypedDict):
-        encoding: str
-        confidence: float
-
-    def detect(byte_str: bytes | bytearray) -> _DetectResultType:
-        """Typed interface for chardet detect method."""
-        ...
-else:
-    from cchardet import detect
-
 from ...models.api_discovery import ApiId
-from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, params_to_dict
+from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, ParamResponse
 from ..api_handler import ApiHandler
 from .brand import BrandParameterHandler
 from .image import ImageParameterHandler
@@ -47,9 +37,10 @@ class Params(ApiHandler[Any]):
 
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
         """Fetch parameter data and convert it into a dictionary."""
-        bytes_data = await self.vapix.api_request(ParamRequest(group))
-        encoding = detect(bytes_data)["encoding"] or "utf-8"
-        return params_to_dict(bytes_data.decode(encoding=encoding)).get("root") or {}
+        response: ParamResponse = await self.vapix.api_request_typed(
+            ParamRequest(group)
+        )
+        return response.data
 
     async def _update(self, group: ParameterGroup | None = None) -> Sequence[str]:
         """Request parameter data and update items."""

--- a/axis/interfaces/pir_sensor_configuration.py
+++ b/axis/interfaces/pir_sensor_configuration.py
@@ -33,17 +33,17 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def list_sensors(self) -> dict[str, PirSensorConfiguration]:
         """List all PIR sensors of device."""
         api_version = self.api_version
-        bytes_data = await self.vapix.api_request(ListSensorsRequest(api_version))
-        response = ListSensorsResponse.decode(bytes_data)
+        response: ListSensorsResponse = await self.vapix.api_request_typed(
+            ListSensorsRequest(api_version)
+        )
         return response.data
 
     async def get_sensitivity(self, id: int) -> float | None:
         """Retrieve configured sensitivity of specific sensor."""
         api_version = self.api_version
-        bytes_data = await self.vapix.api_request(
+        response: GetSensitivityResponse = await self.vapix.api_request_typed(
             GetSensitivityRequest(id, api_version)
         )
-        response = GetSensitivityResponse.decode(bytes_data)
         return response.data
 
     async def set_sensitivity(self, id: int, sensitivity: float) -> None:
@@ -55,6 +55,7 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
         return response.data

--- a/axis/interfaces/port_management.py
+++ b/axis/interfaces/port_management.py
@@ -33,10 +33,10 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_ports(self) -> dict[str, Port]:
         """List ports."""
-        bytes_data = await self.vapix.api_request(
+        response: GetPortsResponse = await self.vapix.api_request_typed(
             GetPortsRequest(api_version=self.api_version)
         )
-        return GetPortsResponse.decode(bytes_data).data
+        return response.data
 
     async def set_ports(
         self, ports: list[PortConfiguration] | PortConfiguration
@@ -69,8 +69,10 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        return GetSupportedVersionsResponse.decode(bytes_data).data
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
+        return response.data
 
     async def open(self, port_id: str) -> None:
         """Shortcut method to open a port."""

--- a/axis/interfaces/pwdgrp_cgi.py
+++ b/axis/interfaces/pwdgrp_cgi.py
@@ -44,8 +44,10 @@ class Users(ApiHandler[User]):
 
     async def list(self) -> dict[str, User]:
         """List current users."""
-        data = await self.vapix.api_request(GetUsersRequest())
-        return GetUsersResponse.decode(data).data
+        response: GetUsersResponse = await self.vapix.api_request_typed(
+            GetUsersRequest()
+        )
+        return response.data
 
     async def create(
         self,

--- a/axis/interfaces/stream_profiles.py
+++ b/axis/interfaces/stream_profiles.py
@@ -33,14 +33,14 @@ class StreamProfilesHandler(ApiHandler[StreamProfile]):
 
     async def list_stream_profiles(self) -> dict[str, StreamProfile]:
         """List all stream profiles."""
-        bytes_data = await self.vapix.api_request(
+        response: ListStreamProfilesResponse = await self.vapix.api_request_typed(
             ListStreamProfilesRequest(api_version=self.api_version)
         )
-        response = ListStreamProfilesResponse.decode(bytes_data)
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
         return response.data

--- a/axis/interfaces/user_groups.py
+++ b/axis/interfaces/user_groups.py
@@ -17,5 +17,7 @@ class UserGroups(ApiHandler[User]):
 
     async def get_user_groups(self) -> dict[str, User]:
         """Retrieve privilege rights for current user."""
-        bytes_data = await self.vapix.api_request(GetUserGroupRequest())
-        return GetUserGroupResponse.decode(bytes_data).data
+        response: GetUserGroupResponse = await self.vapix.api_request_typed(
+            GetUserGroupRequest()
+        )
+        return response.data

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -34,7 +34,7 @@ from .view_areas import ViewAreaHandler
 
 if TYPE_CHECKING:
     from ..device import AxisDevice
-    from ..models.api import ApiRequest, ApiResponseSupportDecode
+    from ..models.api import ApiRequest, ApiResponseBase
     from ..models.stream_profile import StreamProfile
 
 LOGGER = logging.getLogger(__name__)
@@ -268,22 +268,17 @@ class Vapix:
             params=params,
         )
 
-    async def api_request_typed[ApiResponseT: ApiResponseSupportDecode](
+    async def api_request_typed[ApiResponseT: ApiResponseBase](
         self,
         api_request: ApiRequest,
-        response_type: type[ApiResponseT] | None = None,
     ) -> ApiResponseT:
         """Make a request and decode response using the typed response contract."""
-        selected_response_type = response_type or api_request.response_type
-        if selected_response_type is None:
-            msg = (
-                "No response type configured on request; pass response_type "
-                "explicitly or set request.response_type"
-            )
+        if api_request.response_type is None:
+            msg = "No response type configured on request; set request.response_type"
             raise ValueError(msg)
 
         bytes_data = await self.api_request(api_request)
-        decoder = cast("type[ApiResponseT]", selected_response_type)
+        decoder = cast("type[ApiResponseT]", api_request.response_type)
         return decoder.decode(bytes_data)
 
     async def request(

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 
@@ -34,7 +34,7 @@ from .view_areas import ViewAreaHandler
 
 if TYPE_CHECKING:
     from ..device import AxisDevice
-    from ..models.api import ApiRequest
+    from ..models.api import ApiRequest, ApiResponseSupportDecode
     from ..models.stream_profile import StreamProfile
 
 LOGGER = logging.getLogger(__name__)
@@ -267,6 +267,24 @@ class Vapix:
             headers=api_request.headers,
             params=params,
         )
+
+    async def api_request_typed[ApiResponseT: ApiResponseSupportDecode](
+        self,
+        api_request: ApiRequest,
+        response_type: type[ApiResponseT] | None = None,
+    ) -> ApiResponseT:
+        """Make a request and decode response using the typed response contract."""
+        selected_response_type = response_type or api_request.response_type
+        if selected_response_type is None:
+            msg = (
+                "No response type configured on request; pass response_type "
+                "explicitly or set request.response_type"
+            )
+            raise ValueError(msg)
+
+        bytes_data = await self.api_request(api_request)
+        decoder = cast("type[ApiResponseT]", selected_response_type)
+        return decoder.decode(bytes_data)
 
     async def request(
         self,

--- a/axis/interfaces/view_areas.py
+++ b/axis/interfaces/view_areas.py
@@ -36,10 +36,9 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
 
     async def list_view_areas(self) -> dict[str, ViewArea]:
         """List all view areas of device."""
-        bytes_data = await self.vapix.api_request(
+        response: ListViewAreasResponse = await self.vapix.api_request_typed(
             ListViewAreasRequest(self.api_version)
         )
-        response = ListViewAreasResponse.decode(bytes_data)
         return response.data
 
     async def set_geometry(self, id: int, geometry: Geometry) -> dict[str, ViewArea]:
@@ -48,14 +47,13 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        bytes_data = await self.vapix.api_request(
+        response: ListViewAreasResponse = await self.vapix.api_request_typed(
             SetGeometryRequest(
                 id=id,
                 geometry=geometry,
                 api_version=self.api_version,
             )
         )
-        response = ListViewAreasResponse.decode(bytes_data)
         return response.data
 
     async def reset_geometry(self, id: int) -> dict[str, ViewArea]:
@@ -64,20 +62,21 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        bytes_data = await self.vapix.api_request(
+        response: ListViewAreasResponse = await self.vapix.api_request_typed(
             ResetGeometryRequest(id=id, api_version=self.api_version)
         )
-        response = ListViewAreasResponse.decode(bytes_data)
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedVersionsRequest()
+        )
         return response.data
 
     async def get_supported_config_versions(self) -> list[str]:
         """List supported configure API versions."""
-        bytes_data = await self.vapix.api_request(GetSupportedConfigVersionsRequest())
-        response = GetSupportedVersionsResponse.decode(bytes_data)
+        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+            GetSupportedConfigVersionsRequest()
+        )
         return response.data

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Self
+from typing import Any, ClassVar, Self
 
 CONTEXT = "Axis library"
 
@@ -54,6 +54,7 @@ class ApiRequest:
     method: str = field(init=False)
     path: str = field(init=False)
     content_type: str = field(init=False)
+    response_type: ClassVar[type[ApiResponseSupportDecode] | None] = None
 
     @property
     def content(self) -> bytes | None:

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -30,7 +30,7 @@ class ApiItem(ABC):
 
 
 @dataclass
-class ApiResponseSupportDecode(ABC):
+class ApiResponseBase(ABC):
     """Response from API request."""
 
     @classmethod
@@ -40,7 +40,7 @@ class ApiResponseSupportDecode(ABC):
 
 
 @dataclass
-class ApiResponse[ApiDataT](ApiResponseSupportDecode):
+class ApiResponse[ApiDataT](ApiResponseBase):
     """Response from API request."""
 
     data: ApiDataT
@@ -54,7 +54,7 @@ class ApiRequest:
     method: str = field(init=False)
     path: str = field(init=False)
     content_type: str = field(init=False)
-    response_type: ClassVar[type[ApiResponseSupportDecode] | None] = None
+    response_type: ClassVar[type[ApiResponseBase] | None] = None
 
     @property
     def content(self) -> bytes | None:

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -228,6 +228,7 @@ class ListApisRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/apidiscovery.cgi"
     content_type = "application/json"
+    response_type = GetAllApisResponse
     error_codes = error_codes
 
     api_version: str = API_VERSION
@@ -274,6 +275,7 @@ class GetSupportedVersionsRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/apidiscovery.cgi"
     content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
     error_codes = error_codes
 
     context: str = CONTEXT

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -146,15 +146,6 @@ class Application(ApiItem):
 
 
 @dataclass
-class ListApplicationsRequest(ApiRequest):
-    """Request object for listing installed applications."""
-
-    method = "post"
-    path = "/axis-cgi/applications/list.cgi"
-    content_type = "text/xml"
-
-
-@dataclass
 class ListApplicationsResponse(ApiResponse[dict[str, Application]]):
     """Response object for listing all applications."""
 
@@ -168,4 +159,11 @@ class ListApplicationsResponse(ApiResponse[dict[str, Application]]):
         return cls(data=Application.decode_to_dict(apps))
 
 
-ListApplicationsRequest.response_type = ListApplicationsResponse
+@dataclass
+class ListApplicationsRequest(ApiRequest):
+    """Request object for listing installed applications."""
+
+    method = "post"
+    path = "/axis-cgi/applications/list.cgi"
+    content_type = "text/xml"
+    response_type = ListApplicationsResponse

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -166,3 +166,6 @@ class ListApplicationsResponse(ApiResponse[dict[str, Application]]):
         data = xmltodict.parse(bytes_data, attr_prefix="", force_list={"application"})
         apps: list[ApplicationObjectT] = data.get("reply", {}).get("application", [])
         return cls(data=Application.decode_to_dict(apps))
+
+
+ListApplicationsRequest.response_type = ListApplicationsResponse

--- a/axis/models/applications/fence_guard.py
+++ b/axis/models/applications/fence_guard.py
@@ -114,29 +114,6 @@ class Configuration(ApiItem):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
-    """Request object for listing Fence guard configuration."""
-
-    method = "post"
-    path = "/local/fenceguard/control.cgi"
-    content_type = "application/json"
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getConfiguration",
-            }
-        )
-
-
-@dataclass
 class GetConfigurationResponse(ApiResponse[Configuration]):
     """Response object for Fence guard configuration."""
 
@@ -156,4 +133,25 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
         )
 
 
-GetConfigurationRequest.response_type = GetConfigurationResponse
+@dataclass
+class GetConfigurationRequest(ApiRequest):
+    """Request object for listing Fence guard configuration."""
+
+    method = "post"
+    path = "/local/fenceguard/control.cgi"
+    content_type = "application/json"
+    response_type = GetConfigurationResponse
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getConfiguration",
+            }
+        )

--- a/axis/models/applications/fence_guard.py
+++ b/axis/models/applications/fence_guard.py
@@ -154,3 +154,6 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
             method=data["method"],
             data=Configuration.decode(data["data"]),
         )
+
+
+GetConfigurationRequest.response_type = GetConfigurationResponse

--- a/axis/models/applications/loitering_guard.py
+++ b/axis/models/applications/loitering_guard.py
@@ -114,29 +114,6 @@ class Configuration(ApiItem):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
-    """Request object for listing Loitering guard configuration."""
-
-    method = "post"
-    path = "/local/loiteringguard/control.cgi"
-    content_type = "application/json"
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getConfiguration",
-            }
-        )
-
-
-@dataclass
 class GetConfigurationResponse(ApiResponse[Configuration]):
     """Response object for Loitering guard configuration."""
 
@@ -156,4 +133,25 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
         )
 
 
-GetConfigurationRequest.response_type = GetConfigurationResponse
+@dataclass
+class GetConfigurationRequest(ApiRequest):
+    """Request object for listing Loitering guard configuration."""
+
+    method = "post"
+    path = "/local/loiteringguard/control.cgi"
+    content_type = "application/json"
+    response_type = GetConfigurationResponse
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getConfiguration",
+            }
+        )

--- a/axis/models/applications/loitering_guard.py
+++ b/axis/models/applications/loitering_guard.py
@@ -154,3 +154,6 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
             method=data["method"],
             data=Configuration.decode(data["data"]),
         )
+
+
+GetConfigurationRequest.response_type = GetConfigurationResponse

--- a/axis/models/applications/motion_guard.py
+++ b/axis/models/applications/motion_guard.py
@@ -114,29 +114,6 @@ class Configuration(ApiItem):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
-    """Request object for listing Motion guard configuration."""
-
-    method = "post"
-    path = "/local/motionguard/control.cgi"
-    content_type = "application/json"
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getConfiguration",
-            }
-        )
-
-
-@dataclass
 class GetConfigurationResponse(ApiResponse[Configuration]):
     """Response object for Motion guard configuration."""
 
@@ -156,4 +133,25 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
         )
 
 
-GetConfigurationRequest.response_type = GetConfigurationResponse
+@dataclass
+class GetConfigurationRequest(ApiRequest):
+    """Request object for listing Motion guard configuration."""
+
+    method = "post"
+    path = "/local/motionguard/control.cgi"
+    content_type = "application/json"
+    response_type = GetConfigurationResponse
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getConfiguration",
+            }
+        )

--- a/axis/models/applications/motion_guard.py
+++ b/axis/models/applications/motion_guard.py
@@ -154,3 +154,6 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
             method=data["method"],
             data=Configuration.decode(data["data"]),
         )
+
+
+GetConfigurationRequest.response_type = GetConfigurationResponse

--- a/axis/models/applications/object_analytics.py
+++ b/axis/models/applications/object_analytics.py
@@ -218,3 +218,6 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
             method=data["method"],
             data=Configuration.decode(data["data"]),
         )
+
+
+GetConfigurationRequest.response_type = GetConfigurationResponse

--- a/axis/models/applications/object_analytics.py
+++ b/axis/models/applications/object_analytics.py
@@ -177,30 +177,6 @@ class Configuration(ApiItem):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
-    """Request object for listing Object analytics configuration."""
-
-    method = "post"
-    path = "/local/objectanalytics/control.cgi"
-    content_type = "application/json"
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getConfiguration",
-                "params": {},  # Early version of AOA (v1.0-20) requires this
-            }
-        )
-
-
-@dataclass
 class GetConfigurationResponse(ApiResponse[Configuration]):
     """Response object for Object analytics configuration."""
 
@@ -220,4 +196,26 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
         )
 
 
-GetConfigurationRequest.response_type = GetConfigurationResponse
+@dataclass
+class GetConfigurationRequest(ApiRequest):
+    """Request object for listing Object analytics configuration."""
+
+    method = "post"
+    path = "/local/objectanalytics/control.cgi"
+    content_type = "application/json"
+    response_type = GetConfigurationResponse
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getConfiguration",
+                "params": {},  # Early version of AOA (v1.0-20) requires this
+            }
+        )

--- a/axis/models/applications/vmd4.py
+++ b/axis/models/applications/vmd4.py
@@ -109,29 +109,6 @@ class Configuration(ApiItem):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
-    """Request object for listing VMD4 configuration."""
-
-    method = "post"
-    path = "/local/vmd/control.cgi"
-    content_type = "application/json"
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getConfiguration",
-            }
-        )
-
-
-@dataclass
 class GetConfigurationResponse(ApiResponse[Configuration]):
     """Response object for VMD4 configuration."""
 
@@ -151,4 +128,25 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
         )
 
 
-GetConfigurationRequest.response_type = GetConfigurationResponse
+@dataclass
+class GetConfigurationRequest(ApiRequest):
+    """Request object for listing VMD4 configuration."""
+
+    method = "post"
+    path = "/local/vmd/control.cgi"
+    content_type = "application/json"
+    response_type = GetConfigurationResponse
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getConfiguration",
+            }
+        )

--- a/axis/models/applications/vmd4.py
+++ b/axis/models/applications/vmd4.py
@@ -149,3 +149,6 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
             method=data["method"],
             data=Configuration.decode(data["data"]),
         )
+
+
+GetConfigurationRequest.response_type = GetConfigurationResponse

--- a/axis/models/basic_device_info.py
+++ b/axis/models/basic_device_info.py
@@ -150,6 +150,7 @@ class GetAllPropertiesRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/basicdeviceinfo.cgi"
     content_type = "application/json"
+    response_type = GetAllPropertiesResponse
     error_codes = error_codes
 
     api_version: str = API_VERSION
@@ -196,6 +197,7 @@ class GetSupportedVersionsRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/basicdeviceinfo.cgi"
     content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
     error_codes = error_codes
 
     context: str = CONTEXT

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -417,3 +417,6 @@ class ListEventInstancesResponse(ApiResponse[dict[str, Any]]):
         raw_events = traverse(data, EVENT_INSTANCE)  # Move past the irrelevant keys
         events = get_events(raw_events)  # Create topic/data dictionary of events
         return cls(data=EventInstance.decode_to_dict(events))
+
+
+ListEventInstancesRequest.response_type = ListEventInstancesResponse

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -370,35 +370,6 @@ class EventInstance(ApiItem):
 
 
 @dataclass
-class ListEventInstancesRequest(ApiRequest):
-    """Request object for listing installed applications."""
-
-    method = "post"
-    path = "/vapix/services"
-    content_type = "application/soap+xml"
-
-    @property
-    def content(self) -> bytes:
-        """Request content."""
-        return (
-            b'<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">'
-            b'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-            b'xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
-            b'<GetEventInstances xmlns="http://www.axis.com/vapix/ws/event1"/>'
-            b"</s:Body>"
-            b"</s:Envelope>"
-        )
-
-    @property
-    def headers(self) -> dict[str, str]:
-        """Request headers."""
-        return {
-            "Content-Type": "application/soap+xml",
-            "SOAPAction": "http://www.axis.com/vapix/ws/event1/GetEventInstances",
-        }
-
-
-@dataclass
 class ListEventInstancesResponse(ApiResponse[dict[str, Any]]):
     """Response object for listing all applications."""
 
@@ -419,4 +390,31 @@ class ListEventInstancesResponse(ApiResponse[dict[str, Any]]):
         return cls(data=EventInstance.decode_to_dict(events))
 
 
-ListEventInstancesRequest.response_type = ListEventInstancesResponse
+@dataclass
+class ListEventInstancesRequest(ApiRequest):
+    """Request object for listing installed applications."""
+
+    method = "post"
+    path = "/vapix/services"
+    content_type = "application/soap+xml"
+    response_type = ListEventInstancesResponse
+
+    @property
+    def content(self) -> bytes:
+        """Request content."""
+        return (
+            b'<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">'
+            b'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            b'xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+            b'<GetEventInstances xmlns="http://www.axis.com/vapix/ws/event1"/>'
+            b"</s:Body>"
+            b"</s:Envelope>"
+        )
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Request headers."""
+        return {
+            "Content-Type": "application/soap+xml",
+            "SOAPAction": "http://www.axis.com/vapix/ws/event1/GetEventInstances",
+        }

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -1094,3 +1094,21 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
             method=data["method"],
             data=data.get("data", {}).get("apiVersions", []),
         )
+
+
+GetLightInformationRequest.response_type = GetLightInformationResponse
+GetServiceCapabilitiesRequest.response_type = GetServiceCapabilitiesResponse
+GetLightStatusRequest.response_type = GetLightStatusResponse
+GetValidIntensityRequest.response_type = GetValidIntensityResponse
+GetManualIntensityRequest.response_type = GetManualIntensityResponse
+GetIndividualIntensityRequest.response_type = GetIndividualIntensityResponse
+GetCurrentIntensityRequest.response_type = GetCurrentIntensityResponse
+GetValidAngleOfIlluminationRequest.response_type = GetValidAngleOfIlluminationResponse
+GetManualAngleOfIlluminationRequest.response_type = GetManualAngleOfIlluminationResponse
+GetCurrentAngleOfIlluminationRequest.response_type = (
+    GetCurrentAngleOfIlluminationResponse
+)
+GetLightSynchronizeDayNightModeRequest.response_type = (
+    GetLightSynchronizeDayNightModeResponse
+)
+GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -235,30 +235,6 @@ class Range:
 
 
 @dataclass
-class GetLightInformationRequest(ApiRequest):
-    """Request object for getting light information."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getLightInformation",
-            }
-        )
-
-
-@dataclass
 class GetLightInformationResponse(ApiResponse[dict[str, LightInformation]]):
     """Response object for getting light information."""
 
@@ -277,6 +253,31 @@ class GetLightInformationResponse(ApiResponse[dict[str, LightInformation]]):
             context=data["context"],
             method=data["method"],
             data=LightInformation.decode_to_dict(data.get("data", {}).get("items", [])),
+        )
+
+
+@dataclass
+class GetLightInformationRequest(ApiRequest):
+    """Request object for getting light information."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetLightInformationResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getLightInformation",
+            }
         )
 
 
@@ -311,30 +312,6 @@ class ServiceCapabilities:
 
 
 @dataclass
-class GetServiceCapabilitiesRequest(ApiRequest):
-    """Request object for getting service capabilities."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getServiceCapabilities",
-            }
-        )
-
-
-@dataclass
 class GetServiceCapabilitiesResponse(ApiResponse[ServiceCapabilities]):
     """Response object for getting service capabilities."""
 
@@ -353,6 +330,31 @@ class GetServiceCapabilitiesResponse(ApiResponse[ServiceCapabilities]):
             context=data["context"],
             method=data["method"],
             data=ServiceCapabilities.from_dict(data["data"]),
+        )
+
+
+@dataclass
+class GetServiceCapabilitiesRequest(ApiRequest):
+    """Request object for getting service capabilities."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetServiceCapabilitiesResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getServiceCapabilities",
+            }
         )
 
 
@@ -435,33 +437,6 @@ class DisableLightRequest(ActivateLightRequest):
 
 
 @dataclass
-class GetLightStatusRequest(ApiRequest):
-    """Request object for getting light status."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    light_id: str
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getLightStatus",
-                "params": {"lightID": self.light_id},
-            }
-        )
-
-
-@dataclass
 class GetLightStatusResponse(ApiResponse[bool]):
     """Response object for getting light status."""
 
@@ -480,6 +455,34 @@ class GetLightStatusResponse(ApiResponse[bool]):
             context=data["context"],
             method=data["method"],
             data=data["data"]["status"],
+        )
+
+
+@dataclass
+class GetLightStatusRequest(ApiRequest):
+    """Request object for getting light status."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetLightStatusResponse
+    error_codes = general_error_codes
+
+    light_id: str
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getLightStatus",
+                "params": {"lightID": self.light_id},
+            }
         )
 
 
@@ -512,33 +515,6 @@ class SetAutomaticIntensityModeRequest(ApiRequest):
 
 
 @dataclass
-class GetValidIntensityRequest(ApiRequest):
-    """Request object for getting valid intensity range of light."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    light_id: str
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getValidIntensity",
-                "params": {"lightID": self.light_id},
-            }
-        )
-
-
-@dataclass
 class GetValidIntensityResponse(ApiResponse[Range]):
     """Response object for getting valid intensity range of light."""
 
@@ -557,6 +533,34 @@ class GetValidIntensityResponse(ApiResponse[Range]):
             context=data["context"],
             method=data["method"],
             data=Range.from_dict(data["data"]["ranges"][0]),
+        )
+
+
+@dataclass
+class GetValidIntensityRequest(ApiRequest):
+    """Request object for getting valid intensity range of light."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetValidIntensityResponse
+    error_codes = general_error_codes
+
+    light_id: str
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getValidIntensity",
+                "params": {"lightID": self.light_id},
+            }
         )
 
 
@@ -589,33 +593,6 @@ class SetManualIntensityRequest(ApiRequest):
 
 
 @dataclass
-class GetManualIntensityRequest(ApiRequest):
-    """Request object for getting manual intensity."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    light_id: str
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getManualIntensity",
-                "params": {"lightID": self.light_id},
-            }
-        )
-
-
-@dataclass
 class GetManualIntensityResponse(ApiResponse[int]):
     """Response object for getting manual intensity."""
 
@@ -634,6 +611,34 @@ class GetManualIntensityResponse(ApiResponse[int]):
             context=data["context"],
             method=data["method"],
             data=data["data"]["intensity"],
+        )
+
+
+@dataclass
+class GetManualIntensityRequest(ApiRequest):
+    """Request object for getting manual intensity."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetManualIntensityResponse
+    error_codes = general_error_codes
+
+    light_id: str
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getManualIntensity",
+                "params": {"lightID": self.light_id},
+            }
         )
 
 
@@ -671,12 +676,35 @@ class SetIndividualIntensityRequest(ApiRequest):
 
 
 @dataclass
+class GetIndividualIntensityResponse(ApiResponse[int]):
+    """Response object for getting individual intensity."""
+
+    api_version: str
+    context: str
+    method: str
+    data: int
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare API description dictionary."""
+        data: GetIntensityResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=data["data"]["intensity"],
+        )
+
+
+@dataclass
 class GetIndividualIntensityRequest(ApiRequest):
     """Request object for getting individual intensity."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = GetIndividualIntensityResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -699,8 +727,8 @@ class GetIndividualIntensityRequest(ApiRequest):
 
 
 @dataclass
-class GetIndividualIntensityResponse(ApiResponse[int]):
-    """Response object for getting individual intensity."""
+class GetCurrentIntensityResponse(ApiResponse[int]):
+    """Response object for getting current intensity."""
 
     api_version: str
     context: str
@@ -727,6 +755,7 @@ class GetCurrentIntensityRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = GetCurrentIntensityResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -744,28 +773,6 @@ class GetCurrentIntensityRequest(ApiRequest):
                 "method": "getCurrentIntensity",
                 "params": {"lightID": self.light_id},
             }
-        )
-
-
-@dataclass
-class GetCurrentIntensityResponse(ApiResponse[int]):
-    """Response object for getting current intensity."""
-
-    api_version: str
-    context: str
-    method: str
-    data: int
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare API description dictionary."""
-        data: GetIntensityResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=data["data"]["intensity"],
         )
 
 
@@ -798,33 +805,6 @@ class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest):
 
 
 @dataclass
-class GetValidAngleOfIlluminationRequest(ApiRequest):
-    """Request object for getting valid angle of illumination range."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    light_id: str
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getValidAngleOfIllumination",
-                "params": {"lightID": self.light_id},
-            }
-        )
-
-
-@dataclass
 class GetValidAngleOfIlluminationResponse(ApiResponse[list[Range]]):
     """Response object for getting valid angle of illumination range."""
 
@@ -843,6 +823,34 @@ class GetValidAngleOfIlluminationResponse(ApiResponse[list[Range]]):
             context=data["context"],
             method=data["method"],
             data=Range.from_list(data["data"]["ranges"]),
+        )
+
+
+@dataclass
+class GetValidAngleOfIlluminationRequest(ApiRequest):
+    """Request object for getting valid angle of illumination range."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetValidAngleOfIlluminationResponse
+    error_codes = general_error_codes
+
+    light_id: str
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getValidAngleOfIllumination",
+                "params": {"lightID": self.light_id},
+            }
         )
 
 
@@ -878,12 +886,35 @@ class SetManualAngleOfIlluminationModeRequest(ApiRequest):
 
 
 @dataclass
+class GetManualAngleOfIlluminationResponse(ApiResponse[int]):
+    """Response object for getting manual angle of illumination."""
+
+    api_version: str
+    context: str
+    method: str
+    data: int
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare API description dictionary."""
+        data: GetAngleOfIlluminationResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=data["data"]["angleOfIllumination"],
+        )
+
+
+@dataclass
 class GetManualAngleOfIlluminationRequest(ApiRequest):
     """Request object for getting manual angle of illumination."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = GetManualAngleOfIlluminationResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -905,8 +936,8 @@ class GetManualAngleOfIlluminationRequest(ApiRequest):
 
 
 @dataclass
-class GetManualAngleOfIlluminationResponse(ApiResponse[int]):
-    """Response object for getting manual angle of illumination."""
+class GetCurrentAngleOfIlluminationResponse(ApiResponse[int]):
+    """Response object for getting current angle of illumination."""
 
     api_version: str
     context: str
@@ -933,6 +964,7 @@ class GetCurrentAngleOfIlluminationRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = GetCurrentAngleOfIlluminationResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -950,28 +982,6 @@ class GetCurrentAngleOfIlluminationRequest(ApiRequest):
                 "method": "getCurrentAngleOfIllumination",
                 "params": {"lightID": self.light_id},
             }
-        )
-
-
-@dataclass
-class GetCurrentAngleOfIlluminationResponse(ApiResponse[int]):
-    """Response object for getting current angle of illumination."""
-
-    api_version: str
-    context: str
-    method: str
-    data: int
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare API description dictionary."""
-        data: GetAngleOfIlluminationResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=data["data"]["angleOfIllumination"],
         )
 
 
@@ -1004,33 +1014,6 @@ class SetLightSynchronizeDayNightModeRequest(ApiRequest):
 
 
 @dataclass
-class GetLightSynchronizeDayNightModeRequest(ApiRequest):
-    """Request object for getting day night mode synchronization setting."""
-
-    method = "post"
-    path = "/axis-cgi/lightcontrol.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    light_id: str
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getLightSynchronizationDayNightMode",
-                "params": {"lightID": self.light_id},
-            }
-        )
-
-
-@dataclass
 class GetLightSynchronizeDayNightModeResponse(ApiResponse[bool]):
     """Response object for getting day night mode synchronization setting."""
 
@@ -1053,14 +1036,18 @@ class GetLightSynchronizeDayNightModeResponse(ApiResponse[bool]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
-    """Request object for listing supported API versions."""
+class GetLightSynchronizeDayNightModeRequest(ApiRequest):
+    """Request object for getting day night mode synchronization setting."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = GetLightSynchronizeDayNightModeResponse
     error_codes = general_error_codes
 
+    light_id: str
+
+    api_version: str = API_VERSION
     context: str = CONTEXT
 
     @property
@@ -1068,8 +1055,10 @@ class GetSupportedVersionsRequest(ApiRequest):
         """Initialize request data."""
         return orjson.dumps(
             {
+                "apiVersion": self.api_version,
                 "context": self.context,
-                "method": "getSupportedVersions",
+                "method": "getLightSynchronizationDayNightMode",
+                "params": {"lightID": self.light_id},
             }
         )
 
@@ -1096,19 +1085,24 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
         )
 
 
-GetLightInformationRequest.response_type = GetLightInformationResponse
-GetServiceCapabilitiesRequest.response_type = GetServiceCapabilitiesResponse
-GetLightStatusRequest.response_type = GetLightStatusResponse
-GetValidIntensityRequest.response_type = GetValidIntensityResponse
-GetManualIntensityRequest.response_type = GetManualIntensityResponse
-GetIndividualIntensityRequest.response_type = GetIndividualIntensityResponse
-GetCurrentIntensityRequest.response_type = GetCurrentIntensityResponse
-GetValidAngleOfIlluminationRequest.response_type = GetValidAngleOfIlluminationResponse
-GetManualAngleOfIlluminationRequest.response_type = GetManualAngleOfIlluminationResponse
-GetCurrentAngleOfIlluminationRequest.response_type = (
-    GetCurrentAngleOfIlluminationResponse
-)
-GetLightSynchronizeDayNightModeRequest.response_type = (
-    GetLightSynchronizeDayNightModeResponse
-)
-GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse
+@dataclass
+class GetSupportedVersionsRequest(ApiRequest):
+    """Request object for listing supported API versions."""
+
+    method = "post"
+    path = "/axis-cgi/lightcontrol.cgi"
+    content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
+    error_codes = general_error_codes
+
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "context": self.context,
+                "method": "getSupportedVersions",
+            }
+        )

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -676,6 +676,7 @@ class GetClientStatusRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/mqtt/client.cgi"
     content_type = "application/json"
+    response_type = GetClientStatusResponse
     error_codes = general_error_codes
 
     api_version: str = API_VERSION
@@ -724,6 +725,7 @@ class GetEventPublicationConfigRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/mqtt/event.cgi"
     content_type = "application/json"
+    response_type = GetEventPublicationConfigResponse
     error_codes = general_error_codes
 
     api_version: str = API_VERSION

--- a/axis/models/parameters/param_cgi.py
+++ b/axis/models/parameters/param_cgi.py
@@ -3,9 +3,20 @@
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self, TypedDict
 
-from ..api import ApiItem, ApiRequest
+if TYPE_CHECKING:
+
+    class _DetectResultType(TypedDict):
+        encoding: str
+
+    def detect(byte_str: bytes | bytearray) -> _DetectResultType:
+        """Typed interface for chardet detect method."""
+        ...
+else:
+    from cchardet import detect
+
+from ..api import ApiItem, ApiRequest, ApiResponse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -109,3 +120,21 @@ class ParamRequest(ApiRequest):
         if self.group:
             query["group"] = f"root.{self.group}"
         return query
+
+
+@dataclass
+class ParamResponse(ApiResponse[dict[str, Any]]):
+    """Response object for listing parameters."""
+
+    data: dict[str, Any]
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Decode parameter bytes into nested root dictionary."""
+        encoding = detect(bytes_data)["encoding"] or "utf-8"
+        return cls(
+            data=params_to_dict(bytes_data.decode(encoding=encoding)).get("root") or {}
+        )
+
+
+ParamRequest.response_type = ParamResponse

--- a/axis/models/parameters/param_cgi.py
+++ b/axis/models/parameters/param_cgi.py
@@ -104,25 +104,6 @@ class ParamItem(ApiItem):
 
 
 @dataclass
-class ParamRequest(ApiRequest):
-    """Request object for listing parameters."""
-
-    method = "post"
-    path = "/axis-cgi/param.cgi"
-    content_type = "text/plain"
-
-    group: ParameterGroup | None = None
-
-    @property
-    def data(self) -> dict[str, str]:
-        """Request query parameters."""
-        query = {"action": "list"}
-        if self.group:
-            query["group"] = f"root.{self.group}"
-        return query
-
-
-@dataclass
 class ParamResponse(ApiResponse[dict[str, Any]]):
     """Response object for listing parameters."""
 
@@ -137,4 +118,21 @@ class ParamResponse(ApiResponse[dict[str, Any]]):
         )
 
 
-ParamRequest.response_type = ParamResponse
+@dataclass
+class ParamRequest(ApiRequest):
+    """Request object for listing parameters."""
+
+    method = "post"
+    path = "/axis-cgi/param.cgi"
+    content_type = "text/plain"
+    response_type = ParamResponse
+
+    group: ParameterGroup | None = None
+
+    @property
+    def data(self) -> dict[str, str]:
+        """Request query parameters."""
+        query = {"action": "list"}
+        if self.group:
+            query["group"] = f"root.{self.group}"
+        return query

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -147,6 +147,7 @@ class ListSensorsRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/pirsensor.cgi"
     content_type = "application/json"
+    response_type = ListSensorsResponse
     error_codes = general_error_codes
 
     api_version: str = API_VERSION
@@ -193,6 +194,7 @@ class GetSensitivityRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/pirsensor.cgi"
     content_type = "application/json"
+    response_type = GetSensitivityResponse
     error_codes = sensor_specific_error_codes
 
     id: int
@@ -288,3 +290,6 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
             method=data["method"],
             data=data.get("data", {}).get("apiVersions", []),
         )
+
+
+GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -249,28 +249,6 @@ class SetSensitivityRequest(ApiRequest):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
-    """Request object for listing supported API versions."""
-
-    method = "post"
-    path = "/axis-cgi/pirsensor.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "context": self.context,
-                "method": "getSupportedVersions",
-            }
-        )
-
-
-@dataclass
 class GetSupportedVersionsResponse(ApiResponse[list[str]]):
     """Response object for supported versions."""
 
@@ -292,4 +270,24 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
         )
 
 
-GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse
+@dataclass
+class GetSupportedVersionsRequest(ApiRequest):
+    """Request object for listing supported API versions."""
+
+    method = "post"
+    path = "/axis-cgi/pirsensor.cgi"
+    content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
+    error_codes = general_error_codes
+
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "context": self.context,
+                "method": "getSupportedVersions",
+            }
+        )

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -177,30 +177,6 @@ class Port(ApiItem):
 
 
 @dataclass
-class GetPortsRequest(ApiRequest):
-    """Request object for listing ports."""
-
-    method = "post"
-    path = "/axis-cgi/io/portmanagement.cgi"
-    content_type = "application/json"
-    error_codes = error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getPorts",
-            }
-        )
-
-
-@dataclass
 class GetPortsResponse(ApiResponse[dict[str, Port]]):
     """Response object for listing ports."""
 
@@ -219,6 +195,31 @@ class GetPortsResponse(ApiResponse[dict[str, Port]]):
             context=data["context"],
             method=data["method"],
             data=Port.decode_to_dict(data["data"].get("items", [])),
+        )
+
+
+@dataclass
+class GetPortsRequest(ApiRequest):
+    """Request object for listing ports."""
+
+    method = "post"
+    path = "/axis-cgi/io/portmanagement.cgi"
+    content_type = "application/json"
+    response_type = GetPortsResponse
+    error_codes = error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getPorts",
+            }
         )
 
 
@@ -282,28 +283,6 @@ class SetStateSequenceRequest(ApiRequest):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
-    """Request object for listing supported API versions."""
-
-    method = "post"
-    path = "/axis-cgi/io/portmanagement.cgi"
-    content_type = "application/json"
-    error_codes = error_codes
-
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "context": self.context,
-                "method": "getSupportedVersions",
-            }
-        )
-
-
-@dataclass
 class GetSupportedVersionsResponse(ApiResponse[list[str]]):
     """Response object for supported versions."""
 
@@ -325,5 +304,24 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
         )
 
 
-GetPortsRequest.response_type = GetPortsResponse
-GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse
+@dataclass
+class GetSupportedVersionsRequest(ApiRequest):
+    """Request object for listing supported API versions."""
+
+    method = "post"
+    path = "/axis-cgi/io/portmanagement.cgi"
+    content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
+    error_codes = error_codes
+
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "context": self.context,
+                "method": "getSupportedVersions",
+            }
+        )

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -323,3 +323,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
             method=data["method"],
             data=data.get("data", {}).get("apiVersions", []),
         )
+
+
+GetPortsRequest.response_type = GetPortsResponse
+GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -71,20 +71,6 @@ class User(ApiItem):
 
 
 @dataclass
-class GetUsersRequest(ApiRequest):
-    """Request object for listing users."""
-
-    method = "post"
-    path = "/axis-cgi/pwdgrp.cgi"
-    content_type = "text/plain"
-
-    @property
-    def data(self) -> dict[str, str]:
-        """Request data."""
-        return {"action": "get"}
-
-
-@dataclass
 class GetUsersResponse(ApiResponse[dict[str, User]]):
     """Response object for listing ports."""
 
@@ -118,7 +104,19 @@ class GetUsersResponse(ApiResponse[dict[str, User]]):
         return cls(data=User.decode_to_dict(users))
 
 
-GetUsersRequest.response_type = GetUsersResponse
+@dataclass
+class GetUsersRequest(ApiRequest):
+    """Request object for listing users."""
+
+    method = "post"
+    path = "/axis-cgi/pwdgrp.cgi"
+    content_type = "text/plain"
+    response_type = GetUsersResponse
+
+    @property
+    def data(self) -> dict[str, str]:
+        """Request data."""
+        return {"action": "get"}
 
 
 @dataclass

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -118,6 +118,9 @@ class GetUsersResponse(ApiResponse[dict[str, User]]):
         return cls(data=User.decode_to_dict(users))
 
 
+GetUsersRequest.response_type = GetUsersResponse
+
+
 @dataclass
 class CreateUserRequest(ApiRequest):
     """Request object for creating a user."""

--- a/axis/models/stream_profile.py
+++ b/axis/models/stream_profile.py
@@ -146,28 +146,6 @@ class ListStreamProfilesRequest(ApiRequest):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
-    """Request object for listing supported API versions."""
-
-    method = "post"
-    path = "/axis-cgi/streamprofile.cgi"
-    content_type = "application/json"
-    error_codes = error_codes
-
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "context": self.context,
-                "method": "getSupportedVersions",
-            }
-        )
-
-
-@dataclass
 class GetSupportedVersionsResponse(ApiResponse[list[str]]):
     """Response object for supported versions."""
 
@@ -189,4 +167,24 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
         )
 
 
-GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse
+@dataclass
+class GetSupportedVersionsRequest(ApiRequest):
+    """Request object for listing supported API versions."""
+
+    method = "post"
+    path = "/axis-cgi/streamprofile.cgi"
+    content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
+    error_codes = error_codes
+
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "context": self.context,
+                "method": "getSupportedVersions",
+            }
+        )

--- a/axis/models/stream_profile.py
+++ b/axis/models/stream_profile.py
@@ -123,6 +123,7 @@ class ListStreamProfilesRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/streamprofile.cgi"
     content_type = "application/json"
+    response_type = ListStreamProfilesResponse
     error_codes = error_codes
 
     profiles: list[str] = field(default_factory=list)
@@ -186,3 +187,6 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
             method=data["method"],
             data=data.get("data", {}).get("apiVersions", []),
         )
+
+
+GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/axis/models/user_group.py
+++ b/axis/models/user_group.py
@@ -11,15 +11,6 @@ from .pwdgrp_cgi import User, UserGroupsT
 
 
 @dataclass
-class GetUserGroupRequest(ApiRequest):
-    """Request object for listing users."""
-
-    method = "get"
-    path = "/axis-cgi/usergroup.cgi"
-    content_type = "text/plain"
-
-
-@dataclass
 class GetUserGroupResponse(ApiResponse[dict[str, User]]):
     """Response object for listing ports."""
 
@@ -45,4 +36,11 @@ class GetUserGroupResponse(ApiResponse[dict[str, User]]):
         return cls(data={"0": User.decode(user)})
 
 
-GetUserGroupRequest.response_type = GetUserGroupResponse
+@dataclass
+class GetUserGroupRequest(ApiRequest):
+    """Request object for listing users."""
+
+    method = "get"
+    path = "/axis-cgi/usergroup.cgi"
+    content_type = "text/plain"
+    response_type = GetUserGroupResponse

--- a/axis/models/user_group.py
+++ b/axis/models/user_group.py
@@ -43,3 +43,6 @@ class GetUserGroupResponse(ApiResponse[dict[str, User]]):
             "ptz": "ptz" in group_list,
         }
         return cls(data={"0": User.decode(user)})
+
+
+GetUserGroupRequest.response_type = GetUserGroupResponse

--- a/axis/models/view_area.py
+++ b/axis/models/view_area.py
@@ -282,28 +282,6 @@ class ResetGeometryRequest(ApiRequest):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
-    """Request object for listing supported API versions."""
-
-    method = "post"
-    path = "/axis-cgi/viewarea/info.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "context": self.context,
-                "method": "getSupportedVersions",
-            }
-        )
-
-
-@dataclass
 class GetSupportedVersionsResponse(ApiResponse[list[str]]):
     """Response object for supported versions."""
 
@@ -326,10 +304,30 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
+class GetSupportedVersionsRequest(ApiRequest):
+    """Request object for listing supported API versions."""
+
+    method = "post"
+    path = "/axis-cgi/viewarea/info.cgi"
+    content_type = "application/json"
+    response_type = GetSupportedVersionsResponse
+    error_codes = general_error_codes
+
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "context": self.context,
+                "method": "getSupportedVersions",
+            }
+        )
+
+
+@dataclass
 class GetSupportedConfigVersionsRequest(GetSupportedVersionsRequest):
     """Request object for listing supported API versions."""
 
     path = "/axis-cgi/viewarea/configure.cgi"
-
-
-GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/axis/models/view_area.py
+++ b/axis/models/view_area.py
@@ -196,6 +196,7 @@ class ListViewAreasRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/viewarea/info.cgi"
     content_type = "application/json"
+    response_type = ListViewAreasResponse
     error_codes = general_error_codes
 
     api_version: str = API_VERSION
@@ -220,6 +221,7 @@ class SetGeometryRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/viewarea/configure.cgi"
     content_type = "application/json"
+    response_type = ListViewAreasResponse
     error_codes = general_error_codes
 
     id: int
@@ -258,6 +260,7 @@ class ResetGeometryRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/viewarea/configure.cgi"
     content_type = "application/json"
+    response_type = ListViewAreasResponse
     error_codes = general_error_codes
 
     id: int
@@ -327,3 +330,6 @@ class GetSupportedConfigVersionsRequest(GetSupportedVersionsRequest):
     """Request object for listing supported API versions."""
 
     path = "/axis-cgi/viewarea/configure.cgi"
+
+
+GetSupportedVersionsRequest.response_type = GetSupportedVersionsResponse

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -83,13 +83,28 @@ from axis.models.pir_sensor_configuration import (
     ListSensorsRequest,
     ListSensorsResponse,
 )
+from axis.models.port_cgi import PortActionRequest
 from axis.models.port_management import (
     GetPortsRequest,
     GetPortsResponse,
     GetSupportedVersionsRequest as PortManagementGetSupportedVersionsRequest,
     GetSupportedVersionsResponse as PortManagementGetSupportedVersionsResponse,
+    SetPortsRequest,
+    SetStateSequenceRequest,
 )
-from axis.models.pwdgrp_cgi import GetUsersRequest, GetUsersResponse
+from axis.models.ptz_cgi import (
+    DeviceDriverRequest,
+    PtzCommandRequest,
+    PtzControlRequest,
+    QueryRequest,
+)
+from axis.models.pwdgrp_cgi import (
+    CreateUserRequest,
+    DeleteUserRequest,
+    GetUsersRequest,
+    GetUsersResponse,
+    ModifyUserRequest,
+)
 from axis.models.stream_profile import (
     GetSupportedVersionsRequest as StreamProfileGetSupportedVersionsRequest,
     GetSupportedVersionsResponse as StreamProfileGetSupportedVersionsResponse,
@@ -187,3 +202,23 @@ from axis.models.view_area import (
 def test_request_response_type_contracts(request_cls, response_cls) -> None:
     """Verify request classes expose the intended typed response contract."""
     assert request_cls.response_type is response_cls
+
+
+@pytest.mark.parametrize(
+    "request_cls",
+    [
+        PortActionRequest,
+        SetPortsRequest,
+        SetStateSequenceRequest,
+        CreateUserRequest,
+        ModifyUserRequest,
+        DeleteUserRequest,
+        PtzControlRequest,
+        QueryRequest,
+        DeviceDriverRequest,
+        PtzCommandRequest,
+    ],
+)
+def test_write_and_bytes_requests_have_no_response_contract(request_cls) -> None:
+    """Verify non-decoded request classes keep an empty typed response contract."""
+    assert request_cls.response_type is None

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -1,0 +1,189 @@
+"""Tests for request/response typed contract mappings."""
+
+import pytest
+
+from axis.models.api_discovery import (
+    GetAllApisResponse,
+    GetSupportedVersionsRequest as ApiDiscoveryGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as ApiDiscoveryGetSupportedVersionsResponse,
+    ListApisRequest,
+)
+from axis.models.applications.application import (
+    ListApplicationsRequest,
+    ListApplicationsResponse,
+)
+from axis.models.applications.fence_guard import (
+    GetConfigurationRequest as FenceGuardGetConfigurationRequest,
+    GetConfigurationResponse as FenceGuardGetConfigurationResponse,
+)
+from axis.models.applications.loitering_guard import (
+    GetConfigurationRequest as LoiteringGuardGetConfigurationRequest,
+    GetConfigurationResponse as LoiteringGuardGetConfigurationResponse,
+)
+from axis.models.applications.motion_guard import (
+    GetConfigurationRequest as MotionGuardGetConfigurationRequest,
+    GetConfigurationResponse as MotionGuardGetConfigurationResponse,
+)
+from axis.models.applications.object_analytics import (
+    GetConfigurationRequest as ObjectAnalyticsGetConfigurationRequest,
+    GetConfigurationResponse as ObjectAnalyticsGetConfigurationResponse,
+)
+from axis.models.applications.vmd4 import (
+    GetConfigurationRequest as Vmd4GetConfigurationRequest,
+    GetConfigurationResponse as Vmd4GetConfigurationResponse,
+)
+from axis.models.basic_device_info import (
+    GetAllPropertiesRequest,
+    GetAllPropertiesResponse,
+    GetSupportedVersionsRequest as BasicDeviceInfoGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as BasicDeviceInfoGetSupportedVersionsResponse,
+)
+from axis.models.event_instance import (
+    ListEventInstancesRequest,
+    ListEventInstancesResponse,
+)
+from axis.models.light_control import (
+    GetCurrentAngleOfIlluminationRequest,
+    GetCurrentAngleOfIlluminationResponse,
+    GetCurrentIntensityRequest,
+    GetCurrentIntensityResponse,
+    GetIndividualIntensityRequest,
+    GetIndividualIntensityResponse,
+    GetLightInformationRequest,
+    GetLightInformationResponse,
+    GetLightStatusRequest,
+    GetLightStatusResponse,
+    GetLightSynchronizeDayNightModeRequest,
+    GetLightSynchronizeDayNightModeResponse,
+    GetManualAngleOfIlluminationRequest,
+    GetManualAngleOfIlluminationResponse,
+    GetManualIntensityRequest,
+    GetManualIntensityResponse,
+    GetServiceCapabilitiesRequest,
+    GetServiceCapabilitiesResponse,
+    GetSupportedVersionsRequest as LightControlGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as LightControlGetSupportedVersionsResponse,
+    GetValidAngleOfIlluminationRequest,
+    GetValidAngleOfIlluminationResponse,
+    GetValidIntensityRequest,
+    GetValidIntensityResponse,
+)
+from axis.models.mqtt import (
+    GetClientStatusRequest,
+    GetClientStatusResponse,
+    GetEventPublicationConfigRequest,
+    GetEventPublicationConfigResponse,
+)
+from axis.models.parameters.param_cgi import ParamRequest, ParamResponse
+from axis.models.pir_sensor_configuration import (
+    GetSensitivityRequest,
+    GetSensitivityResponse,
+    GetSupportedVersionsRequest as PirSensorGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as PirSensorGetSupportedVersionsResponse,
+    ListSensorsRequest,
+    ListSensorsResponse,
+)
+from axis.models.port_management import (
+    GetPortsRequest,
+    GetPortsResponse,
+    GetSupportedVersionsRequest as PortManagementGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as PortManagementGetSupportedVersionsResponse,
+)
+from axis.models.pwdgrp_cgi import GetUsersRequest, GetUsersResponse
+from axis.models.stream_profile import (
+    GetSupportedVersionsRequest as StreamProfileGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as StreamProfileGetSupportedVersionsResponse,
+    ListStreamProfilesRequest,
+    ListStreamProfilesResponse,
+)
+from axis.models.user_group import GetUserGroupRequest, GetUserGroupResponse
+from axis.models.view_area import (
+    GetSupportedVersionsRequest as ViewAreaGetSupportedVersionsRequest,
+    GetSupportedVersionsResponse as ViewAreaGetSupportedVersionsResponse,
+    ListViewAreasRequest,
+    ListViewAreasResponse,
+    ResetGeometryRequest,
+    SetGeometryRequest,
+)
+
+
+@pytest.mark.parametrize(
+    ("request_cls", "response_cls"),
+    [
+        (ListApisRequest, GetAllApisResponse),
+        (
+            ApiDiscoveryGetSupportedVersionsRequest,
+            ApiDiscoveryGetSupportedVersionsResponse,
+        ),
+        (GetAllPropertiesRequest, GetAllPropertiesResponse),
+        (
+            BasicDeviceInfoGetSupportedVersionsRequest,
+            BasicDeviceInfoGetSupportedVersionsResponse,
+        ),
+        (ListEventInstancesRequest, ListEventInstancesResponse),
+        (ListApplicationsRequest, ListApplicationsResponse),
+        (FenceGuardGetConfigurationRequest, FenceGuardGetConfigurationResponse),
+        (
+            LoiteringGuardGetConfigurationRequest,
+            LoiteringGuardGetConfigurationResponse,
+        ),
+        (MotionGuardGetConfigurationRequest, MotionGuardGetConfigurationResponse),
+        (
+            ObjectAnalyticsGetConfigurationRequest,
+            ObjectAnalyticsGetConfigurationResponse,
+        ),
+        (Vmd4GetConfigurationRequest, Vmd4GetConfigurationResponse),
+        (GetLightInformationRequest, GetLightInformationResponse),
+        (GetServiceCapabilitiesRequest, GetServiceCapabilitiesResponse),
+        (GetLightStatusRequest, GetLightStatusResponse),
+        (GetValidIntensityRequest, GetValidIntensityResponse),
+        (GetManualIntensityRequest, GetManualIntensityResponse),
+        (GetIndividualIntensityRequest, GetIndividualIntensityResponse),
+        (GetCurrentIntensityRequest, GetCurrentIntensityResponse),
+        (
+            GetValidAngleOfIlluminationRequest,
+            GetValidAngleOfIlluminationResponse,
+        ),
+        (
+            GetManualAngleOfIlluminationRequest,
+            GetManualAngleOfIlluminationResponse,
+        ),
+        (
+            GetCurrentAngleOfIlluminationRequest,
+            GetCurrentAngleOfIlluminationResponse,
+        ),
+        (
+            GetLightSynchronizeDayNightModeRequest,
+            GetLightSynchronizeDayNightModeResponse,
+        ),
+        (
+            LightControlGetSupportedVersionsRequest,
+            LightControlGetSupportedVersionsResponse,
+        ),
+        (GetClientStatusRequest, GetClientStatusResponse),
+        (GetEventPublicationConfigRequest, GetEventPublicationConfigResponse),
+        (ParamRequest, ParamResponse),
+        (ListSensorsRequest, ListSensorsResponse),
+        (GetSensitivityRequest, GetSensitivityResponse),
+        (PirSensorGetSupportedVersionsRequest, PirSensorGetSupportedVersionsResponse),
+        (GetPortsRequest, GetPortsResponse),
+        (
+            PortManagementGetSupportedVersionsRequest,
+            PortManagementGetSupportedVersionsResponse,
+        ),
+        (GetUsersRequest, GetUsersResponse),
+        (ListStreamProfilesRequest, ListStreamProfilesResponse),
+        (
+            StreamProfileGetSupportedVersionsRequest,
+            StreamProfileGetSupportedVersionsResponse,
+        ),
+        (GetUserGroupRequest, GetUserGroupResponse),
+        (ListViewAreasRequest, ListViewAreasResponse),
+        (SetGeometryRequest, ListViewAreasResponse),
+        (ResetGeometryRequest, ListViewAreasResponse),
+        (ViewAreaGetSupportedVersionsRequest, ViewAreaGetSupportedVersionsResponse),
+    ],
+)
+def test_request_response_type_contracts(request_cls, response_cls) -> None:
+    """Verify request classes expose the intended typed response contract."""
+    assert request_cls.response_type is response_cls

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -69,6 +69,10 @@ from axis.models.light_control import (
     GetValidIntensityResponse,
 )
 from axis.models.mqtt import (
+    ActivateClientRequest,
+    ConfigureClientRequest,
+    ConfigureEventPublicationRequest,
+    DeactivateClientRequest,
     GetClientStatusRequest,
     GetClientStatusResponse,
     GetEventPublicationConfigRequest,
@@ -207,6 +211,10 @@ def test_request_response_type_contracts(request_cls, response_cls) -> None:
 @pytest.mark.parametrize(
     "request_cls",
     [
+        ActivateClientRequest,
+        ConfigureClientRequest,
+        ConfigureEventPublicationRequest,
+        DeactivateClientRequest,
         PortActionRequest,
         SetPortsRequest,
         SetStateSequenceRequest,

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -390,20 +390,17 @@ async def test_api_request_typed_requires_response_type(vapix: Vapix):
         await vapix.api_request_typed(SetPortsRequest(PortConfiguration(port="0")))
 
 
-async def test_api_request_typed_accepts_explicit_response_type(
+async def test_api_request_typed_decodes_using_request_response_type(
     mock_vapix_request, vapix: Vapix
 ):
-    """Verify typed helper accepts an explicit response type override argument."""
+    """Verify typed helper decodes response using the request's response_type contract."""
     mock_vapix_request(
         GetUserGroupRequest,
         text="root\nroot admin operator ptz viewer\n",
         headers={"Content-Type": "text/plain"},
     )
 
-    response = await vapix.api_request_typed(
-        GetUserGroupRequest(),
-        response_type=GetUserGroupResponse,
-    )
+    response = await vapix.api_request_typed(GetUserGroupRequest())
 
     assert isinstance(response, GetUserGroupResponse)
     assert response.data["0"].admin

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -353,6 +353,37 @@ async def test_api_request_typed_uses_request_response_type(
     assert response.data == {}
 
 
+async def test_api_request_typed_uses_param_request_response_type(
+    mock_vapix_request, vapix: Vapix
+):
+    """Verify typed request decoding uses ParamRequest response metadata."""
+    mock_vapix_request(
+        ParamRequest,
+        text=PARAM_CGI_RESPONSE,
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
+
+    response = await vapix.api_request_typed(ParamRequest())
+
+    assert "Brand" in response.data
+    assert response.data["Brand"]["Brand"] == "AXIS"
+
+
+async def test_api_request_typed_uses_applications_request_response_type(
+    mock_vapix_request, vapix: Vapix
+):
+    """Verify typed request decoding uses ListApplicationsRequest metadata."""
+    mock_vapix_request(
+        ListApplicationsRequest,
+        text=APPLICATIONS_RESPONSE,
+        headers={"Content-Type": "text/xml"},
+    )
+
+    response = await vapix.api_request_typed(ListApplicationsRequest())
+
+    assert response.data["vmd"].status == ApplicationStatus.RUNNING
+
+
 async def test_api_request_typed_requires_response_type(vapix: Vapix):
     """Verify typed request helper errors when request has no response contract."""
     with pytest.raises(ValueError, match="No response type configured"):

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -26,7 +26,7 @@ from axis.models.parameters.param_cgi import ParamRequest
 from axis.models.port_management import GetPortsRequest
 from axis.models.pwdgrp_cgi import SecondaryGroup
 from axis.models.stream_profile import ListStreamProfilesRequest, StreamProfile
-from axis.models.view_area import ListViewAreasRequest
+from axis.models.view_area import ListViewAreasRequest, ListViewAreasResponse
 
 from .applications.test_applications import (
     LIST_APPLICATIONS_RESPONSE as APPLICATIONS_RESPONSE,
@@ -326,6 +326,32 @@ async def test_initialize_api_discovery(mock_vapix_request, vapix: Vapix):
     assert len(vapix.light_control) == 1
     assert len(vapix.mqtt) == 0
     assert len(vapix.stream_profiles) == 1
+
+
+async def test_api_request_typed_uses_request_response_type(
+    mock_vapix_request, vapix: Vapix
+):
+    """Verify typed request decoding can use request-level response metadata."""
+    mock_vapix_request(
+        ListViewAreasRequest,
+        json={
+            "apiVersion": "1.0",
+            "context": "",
+            "method": "list",
+            "data": {"viewAreas": []},
+        },
+    )
+
+    response = await vapix.api_request_typed(ListViewAreasRequest(api_version="1.0"))
+
+    assert isinstance(response, ListViewAreasResponse)
+    assert response.data == {}
+
+
+async def test_api_request_typed_requires_response_type(vapix: Vapix):
+    """Verify typed request helper errors when request has no response contract."""
+    with pytest.raises(ValueError, match="No response type configured"):
+        await vapix.api_request_typed(ParamRequest())
 
 
 async def test_initialize_api_discovery_unauthorized(http_route_mock, vapix: Vapix):

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -23,7 +23,11 @@ from axis.models.applications.application import (
 from axis.models.basic_device_info import GetAllPropertiesRequest
 from axis.models.light_control import GetLightInformationRequest
 from axis.models.parameters.param_cgi import ParamRequest
-from axis.models.port_management import GetPortsRequest
+from axis.models.port_management import (
+    GetPortsRequest,
+    PortConfiguration,
+    SetPortsRequest,
+)
 from axis.models.pwdgrp_cgi import SecondaryGroup
 from axis.models.stream_profile import ListStreamProfilesRequest, StreamProfile
 from axis.models.user_group import GetUserGroupRequest, GetUserGroupResponse
@@ -352,7 +356,7 @@ async def test_api_request_typed_uses_request_response_type(
 async def test_api_request_typed_requires_response_type(vapix: Vapix):
     """Verify typed request helper errors when request has no response contract."""
     with pytest.raises(ValueError, match="No response type configured"):
-        await vapix.api_request_typed(ParamRequest())
+        await vapix.api_request_typed(SetPortsRequest(PortConfiguration(port="0")))
 
 
 async def test_api_request_typed_accepts_explicit_response_type(

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -26,6 +26,7 @@ from axis.models.parameters.param_cgi import ParamRequest
 from axis.models.port_management import GetPortsRequest
 from axis.models.pwdgrp_cgi import SecondaryGroup
 from axis.models.stream_profile import ListStreamProfilesRequest, StreamProfile
+from axis.models.user_group import GetUserGroupRequest, GetUserGroupResponse
 from axis.models.view_area import ListViewAreasRequest, ListViewAreasResponse
 
 from .applications.test_applications import (
@@ -352,6 +353,25 @@ async def test_api_request_typed_requires_response_type(vapix: Vapix):
     """Verify typed request helper errors when request has no response contract."""
     with pytest.raises(ValueError, match="No response type configured"):
         await vapix.api_request_typed(ParamRequest())
+
+
+async def test_api_request_typed_accepts_explicit_response_type(
+    mock_vapix_request, vapix: Vapix
+):
+    """Verify typed helper accepts an explicit response type override argument."""
+    mock_vapix_request(
+        GetUserGroupRequest,
+        text="root\nroot admin operator ptz viewer\n",
+        headers={"Content-Type": "text/plain"},
+    )
+
+    response = await vapix.api_request_typed(
+        GetUserGroupRequest(),
+        response_type=GetUserGroupResponse,
+    )
+
+    assert isinstance(response, GetUserGroupResponse)
+    assert response.data["0"].admin
 
 
 async def test_initialize_api_discovery_unauthorized(http_route_mock, vapix: Vapix):


### PR DESCRIPTION
## What does this PR do?

Refactors request/response handling by introducing a typed request helper (`Vapix.api_request_typed`) and wiring response metadata on request models, while preserving existing interface-layer behavior.

## Compatibility and Scope

- Internal refactor focused on typing and call-site consistency.
- Interface-layer method signatures and return shapes are unchanged.
- Expected Home Assistant integration behavior is unchanged because consumers use interface methods, not model decode internals.

## Architecture Layer(s)

- [x] Models (`axis/models/`)
- [x] Interfaces (`axis/interfaces/`)
- [x] Orchestration (`axis/interfaces/vapix.py`)
- [x] Tests

## Type of Change

- [ ] New feature (handler, interface, model)
- [ ] Bug fix (minimal, targeted)
- [x] Refactor (no behavior change)
- [ ] Documentation

## Related Issues

Closes #806

## Verification Checklist

- [x] `uv run ruff check axis tests` passes
- [x] `uv run ruff format --check axis tests` passes
- [x] `uv run mypy axis` passes
- [x] `uv run pytest` passes (coverage >=95%)
- [x] Focused tests executed for migrated slices and `tests/test_vapix.py`
- [x] Commit hooks modified files were re-staged and checks re-run
- [x] No unrelated code/formatting changes
- [x] Follows existing conventions for boundary parsing and normalization

## Notes for Reviewers

Key pattern introduced:
- `ApiRequest.response_type` metadata in models.
- `Vapix.api_request_typed(request, response_type=None)` in orchestration.
- Interface handlers migrate from `bytes + Response.decode(...)` to typed helper calls.

Migration in this PR is incremental and focused on read paths where decoding occurs.
Write-only request methods remain unchanged where no response decoding is needed.

Known tradeoff:
- Static typing is improved at call sites but request/response pairing is still runtime metadata based.
- A stronger generic pairing model can be a follow-up without changing this PR’s behavior.

## Validation Summary

Latest full branch run:
- 433 tests passed
- Coverage: 97.95%
- Lint/format/mypy checks passed
