### PR TITLE
feat: Make ApiRequest generic with explicit response contracts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,8 @@
 - Prefer root-cause fixes over workarounds.
 - For enums and external inputs, preserve existing defensive normalization patterns (for example `_missing_` fallbacks and constructor normalization).
 - For event/XML handling, preserve namespace-aware parsing and root-shape guards instead of assuming a fixed payload shape.
+- For request models, keep the generic `ApiRequest[T]` contract aligned with runtime `response_type` metadata on every subclass.
+- Use `BytesResponse` for write/raw-byte request classes instead of implicit defaults.
 
 ## Testing Conventions
 
@@ -66,6 +68,7 @@ Related issue: [link or #number].
 - Overall coverage must stay ≥95%
 - Reuse fixtures from tests/conftest.py
 - If enums are involved, include _missing_ fallback
+- Every ApiRequest subclass must declare an explicit response_type consistent with its generic argument
 - Keep changes minimal and targeted (no unrelated refactoring)
 
 [TASK]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,18 @@ This project uses PEP 695 syntax for new or updated typing code:
 - Use `type` statements for aliases instead of assignment-style aliases.
 - Do not introduce new module-level `TypeVar(...)` declarations when class or function type parameters are sufficient.
 
+### Request and response contracts
+
+Request classes are part of the public typing boundary and must keep static and runtime decode contracts aligned.
+
+- Use `ApiRequest[ConcreteResponse]` for decoded/read requests.
+- Set `response_type = ConcreteResponse` on every decoded/read request class.
+- Use `ApiRequest[ApiResponse[bytes]]` for write/raw-byte requests.
+- Set `response_type = BytesResponse` on every write/raw-byte request class.
+- Do not rely on implicit `response_type` defaults.
+
+If an interface method intentionally preserves a legacy `bytes` return type, unwrap `.data` at the handler boundary rather than changing `Vapix.api_request()` semantics.
+
 ## Tests
 
 Tests live in `tests/` and mirror the `axis/` structure. Use the nearest relevant test module for any behavior change.

--- a/COPILOT_QUICK_START.md
+++ b/COPILOT_QUICK_START.md
@@ -23,6 +23,10 @@ This guide helps you get the most out of Copilot when contributing to the Axis l
 3. Register it on `Vapix` in `axis/interfaces/vapix.py`.
 4. Add tests in `tests/test_<name>.py` using fixtures from `tests/conftest.py`.
 
+For request models:
+- Use `ApiRequest[ConcreteResponse]` plus `response_type = ConcreteResponse` for decoded responses.
+- Use `ApiRequest[ApiResponse[bytes]]` plus `response_type = BytesResponse` for write/raw-byte responses.
+
 **Copilot request:**
 ```
 I need to add a new handler for [feature].
@@ -41,6 +45,7 @@ This handler should participate in the [API_DISCOVERY / PARAM_CGI_FALLBACK / APP
 - 100% test coverage for new code
 - All enums have _missing_ fallback
 - Input normalization in __post_init__
+- Explicit request response_type on every ApiRequest subclass
 - Preserve existing behavior
 
 [VERIFICATION]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ Vapix initialization is phase-based and driven by handler metadata:
 
 Handlers declare phase membership through `handler_groups` and may customize phase eligibility through `should_initialize_in_group`.
 
+## Request and response typing
+
+`Vapix.api_request()` is the single typed request entrypoint.
+
+- Request models declare their decode contract with `ApiRequest[ResponseT]`.
+- Every `ApiRequest` subclass must set `response_type` explicitly.
+- Decoded/read requests use their concrete response model as `response_type`.
+- Write-style requests use `BytesResponse` as `response_type`.
+
+Examples:
+
+```python
+@dataclass
+class ListApisRequest(ApiRequest[GetAllApisResponse]):
+	response_type = GetAllApisResponse
+
+
+@dataclass
+class SetPortsRequest(ApiRequest[ApiResponse[bytes]]):
+	response_type = BytesResponse
+```
+
+Handler methods may unwrap `.data` when they intentionally preserve a bytes-returning boundary.
+
 Example fallback policy:
 
 - `LightHandler` participates in both `API_DISCOVERY` and `PARAM_CGI_FALLBACK`.

--- a/axis/interfaces/api_discovery.py
+++ b/axis/interfaces/api_discovery.py
@@ -8,9 +8,7 @@ from ..models.api_discovery import (
     API_VERSION,
     Api,
     ApiId,
-    GetAllApisResponse,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     ListApisRequest,
 )
 from .api_handler import ApiHandler
@@ -33,12 +31,10 @@ class ApiDiscoveryHandler(ApiHandler[Api]):
 
     async def get_api_list(self) -> dict[str, Api]:
         """List all APIs registered on API Discovery service."""
-        response: GetAllApisResponse = await self.vapix.api_request(ListApisRequest())
+        response = await self.vapix.api_request(ListApisRequest())
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data

--- a/axis/interfaces/api_discovery.py
+++ b/axis/interfaces/api_discovery.py
@@ -33,14 +33,14 @@ class ApiDiscoveryHandler(ApiHandler[Api]):
 
     async def get_api_list(self) -> dict[str, Api]:
         """List all APIs registered on API Discovery service."""
-        response: GetAllApisResponse = await self.vapix.api_request_typed(
+        response: GetAllApisResponse = await self.vapix.api_request(
             ListApisRequest()
         )
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/api_discovery.py
+++ b/axis/interfaces/api_discovery.py
@@ -33,9 +33,7 @@ class ApiDiscoveryHandler(ApiHandler[Api]):
 
     async def get_api_list(self) -> dict[str, Api]:
         """List all APIs registered on API Discovery service."""
-        response: GetAllApisResponse = await self.vapix.api_request(
-            ListApisRequest()
-        )
+        response: GetAllApisResponse = await self.vapix.api_request(ListApisRequest())
         return response.data
 
     async def get_supported_versions(self) -> list[str]:

--- a/axis/interfaces/applications/applications.py
+++ b/axis/interfaces/applications/applications.py
@@ -36,7 +36,7 @@ class ApplicationsHandler(ApiHandler[Application]):
 
     async def list_applications(self) -> dict[str, Application]:
         """List all APIs registered on API Discovery service."""
-        response: ListApplicationsResponse = await self.vapix.api_request_typed(
+        response: ListApplicationsResponse = await self.vapix.api_request(
             ListApplicationsRequest()
         )
         return response.data

--- a/axis/interfaces/applications/applications.py
+++ b/axis/interfaces/applications/applications.py
@@ -9,7 +9,6 @@ from packaging import version
 from ...models.applications.application import (
     Application,
     ListApplicationsRequest,
-    ListApplicationsResponse,
 )
 from ..api_handler import ApiHandler
 
@@ -36,7 +35,5 @@ class ApplicationsHandler(ApiHandler[Application]):
 
     async def list_applications(self) -> dict[str, Application]:
         """List all APIs registered on API Discovery service."""
-        response: ListApplicationsResponse = await self.vapix.api_request(
-            ListApplicationsRequest()
-        )
+        response = await self.vapix.api_request(ListApplicationsRequest())
         return response.data

--- a/axis/interfaces/applications/fence_guard.py
+++ b/axis/interfaces/applications/fence_guard.py
@@ -22,7 +22,7 @@ class FenceGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+        response: GetConfigurationResponse = await self.vapix.api_request(
             GetConfigurationRequest()
         )
         return response.data

--- a/axis/interfaces/applications/fence_guard.py
+++ b/axis/interfaces/applications/fence_guard.py
@@ -10,7 +10,6 @@ from ...models.applications.application import ApplicationName
 from ...models.applications.fence_guard import (
     Configuration,
     GetConfigurationRequest,
-    GetConfigurationResponse,
 )
 from .application_handler import ApplicationHandler
 
@@ -22,7 +21,5 @@ class FenceGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request(
-            GetConfigurationRequest()
-        )
+        response = await self.vapix.api_request(GetConfigurationRequest())
         return response.data

--- a/axis/interfaces/applications/loitering_guard.py
+++ b/axis/interfaces/applications/loitering_guard.py
@@ -20,7 +20,7 @@ class LoiteringGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+        response: GetConfigurationResponse = await self.vapix.api_request(
             GetConfigurationRequest()
         )
         return response.data

--- a/axis/interfaces/applications/loitering_guard.py
+++ b/axis/interfaces/applications/loitering_guard.py
@@ -8,7 +8,6 @@ from ...models.applications.application import ApplicationName
 from ...models.applications.loitering_guard import (
     Configuration,
     GetConfigurationRequest,
-    GetConfigurationResponse,
 )
 from .application_handler import ApplicationHandler
 
@@ -20,7 +19,5 @@ class LoiteringGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request(
-            GetConfigurationRequest()
-        )
+        response = await self.vapix.api_request(GetConfigurationRequest())
         return response.data

--- a/axis/interfaces/applications/motion_guard.py
+++ b/axis/interfaces/applications/motion_guard.py
@@ -21,7 +21,7 @@ class MotionGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+        response: GetConfigurationResponse = await self.vapix.api_request(
             GetConfigurationRequest()
         )
         return response.data

--- a/axis/interfaces/applications/motion_guard.py
+++ b/axis/interfaces/applications/motion_guard.py
@@ -9,7 +9,6 @@ from ...models.applications.application import ApplicationName
 from ...models.applications.motion_guard import (
     Configuration,
     GetConfigurationRequest,
-    GetConfigurationResponse,
 )
 from .application_handler import ApplicationHandler
 
@@ -21,7 +20,5 @@ class MotionGuardHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request(
-            GetConfigurationRequest()
-        )
+        response = await self.vapix.api_request(GetConfigurationRequest())
         return response.data

--- a/axis/interfaces/applications/object_analytics.py
+++ b/axis/interfaces/applications/object_analytics.py
@@ -19,7 +19,7 @@ class ObjectAnalyticsHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of object analytics application."""
-        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+        response: GetConfigurationResponse = await self.vapix.api_request(
             GetConfigurationRequest()
         )
         return response.data

--- a/axis/interfaces/applications/object_analytics.py
+++ b/axis/interfaces/applications/object_analytics.py
@@ -7,7 +7,6 @@ from ...models.applications.application import ApplicationName
 from ...models.applications.object_analytics import (
     Configuration,
     GetConfigurationRequest,
-    GetConfigurationResponse,
 )
 from .application_handler import ApplicationHandler
 
@@ -19,7 +18,5 @@ class ObjectAnalyticsHandler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of object analytics application."""
-        response: GetConfigurationResponse = await self.vapix.api_request(
-            GetConfigurationRequest()
-        )
+        response = await self.vapix.api_request(GetConfigurationRequest())
         return response.data

--- a/axis/interfaces/applications/vmd4.py
+++ b/axis/interfaces/applications/vmd4.py
@@ -4,7 +4,6 @@ from ...models.applications.application import ApplicationName
 from ...models.applications.vmd4 import (
     Configuration,
     GetConfigurationRequest,
-    GetConfigurationResponse,
 )
 from .application_handler import ApplicationHandler
 
@@ -16,7 +15,5 @@ class Vmd4Handler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request(
-            GetConfigurationRequest()
-        )
+        response = await self.vapix.api_request(GetConfigurationRequest())
         return response.data

--- a/axis/interfaces/applications/vmd4.py
+++ b/axis/interfaces/applications/vmd4.py
@@ -16,7 +16,7 @@ class Vmd4Handler(ApplicationHandler[Configuration]):
 
     async def get_configuration(self) -> Configuration:
         """Get configuration of VMD4 application."""
-        response: GetConfigurationResponse = await self.vapix.api_request_typed(
+        response: GetConfigurationResponse = await self.vapix.api_request(
             GetConfigurationRequest()
         )
         return response.data

--- a/axis/interfaces/basic_device_info.py
+++ b/axis/interfaces/basic_device_info.py
@@ -10,9 +10,7 @@ from ..models.basic_device_info import (
     API_VERSION,
     DeviceInformation,
     GetAllPropertiesRequest,
-    GetAllPropertiesResponse,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
 )
 from .api_handler import ApiHandler, HandlerGroup
 
@@ -30,14 +28,12 @@ class BasicDeviceInfoHandler(ApiHandler[DeviceInformation]):
 
     async def get_all_properties(self) -> dict[str, DeviceInformation]:
         """List all properties of basic device info."""
-        response: GetAllPropertiesResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetAllPropertiesRequest(self.api_version)
         )
         return {"0": response.data}
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data

--- a/axis/interfaces/basic_device_info.py
+++ b/axis/interfaces/basic_device_info.py
@@ -30,14 +30,14 @@ class BasicDeviceInfoHandler(ApiHandler[DeviceInformation]):
 
     async def get_all_properties(self) -> dict[str, DeviceInformation]:
         """List all properties of basic device info."""
-        response: GetAllPropertiesResponse = await self.vapix.api_request_typed(
+        response: GetAllPropertiesResponse = await self.vapix.api_request(
             GetAllPropertiesRequest(self.api_version)
         )
         return {"0": response.data}
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/event_instances.py
+++ b/axis/interfaces/event_instances.py
@@ -23,7 +23,7 @@ class EventInstanceHandler(ApiHandler[EventInstance]):
 
     async def get_event_instances(self) -> dict[str, EventInstance]:
         """List all event instances."""
-        response: ListEventInstancesResponse = await self.vapix.api_request_typed(
+        response: ListEventInstancesResponse = await self.vapix.api_request(
             ListEventInstancesRequest()
         )
         return response.data

--- a/axis/interfaces/event_instances.py
+++ b/axis/interfaces/event_instances.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from ..models.event_instance import (
     EventInstance,
     ListEventInstancesRequest,
-    ListEventInstancesResponse,
 )
 from .api_handler import ApiHandler
 from .event_manager import BLACK_LISTED_TOPICS
@@ -23,9 +22,7 @@ class EventInstanceHandler(ApiHandler[EventInstance]):
 
     async def get_event_instances(self) -> dict[str, EventInstance]:
         """List all event instances."""
-        response: ListEventInstancesResponse = await self.vapix.api_request(
-            ListEventInstancesRequest()
-        )
+        response = await self.vapix.api_request(ListEventInstancesRequest())
         return response.data
 
     def get_expected_events_per_topic(

--- a/axis/interfaces/light_control.py
+++ b/axis/interfaces/light_control.py
@@ -12,29 +12,18 @@ from ..models.light_control import (
     DisableLightRequest,
     EnableLightRequest,
     GetCurrentAngleOfIlluminationRequest,
-    GetCurrentAngleOfIlluminationResponse,
     GetCurrentIntensityRequest,
-    GetCurrentIntensityResponse,
     GetIndividualIntensityRequest,
-    GetIndividualIntensityResponse,
     GetLightInformationRequest,
-    GetLightInformationResponse,
     GetLightStatusRequest,
-    GetLightStatusResponse,
     GetLightSynchronizeDayNightModeRequest,
     GetLightSynchronizeDayNightModeResponse,
     GetManualAngleOfIlluminationRequest,
-    GetManualAngleOfIlluminationResponse,
     GetManualIntensityRequest,
-    GetManualIntensityResponse,
     GetServiceCapabilitiesRequest,
-    GetServiceCapabilitiesResponse,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     GetValidAngleOfIlluminationRequest,
-    GetValidAngleOfIlluminationResponse,
     GetValidIntensityRequest,
-    GetValidIntensityResponse,
     LightInformation,
     Range,
     ServiceCapabilities,
@@ -77,14 +66,14 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_information(self) -> dict[str, LightInformation]:
         """List the light control information."""
-        response: GetLightInformationResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetLightInformationRequest(api_version=self.api_version)
         )
         return response.data
 
     async def get_service_capabilities(self) -> ServiceCapabilities:
         """List the light control information."""
-        response: GetServiceCapabilitiesResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetServiceCapabilitiesRequest(api_version=self.api_version)
         )
         return response.data
@@ -115,7 +104,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_status(self, light_id: str) -> bool:
         """Get light status if its on or off."""
-        response: GetLightStatusResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetLightStatusRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -132,7 +121,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_intensity(self, light_id: str) -> Range:
         """Get valid intensity range for light."""
-        response: GetValidIntensityResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetValidIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -149,7 +138,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_intensity(self, light_id: str) -> int:
         """Enable the automatic light intensity control."""
-        response: GetManualIntensityResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetManualIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -169,7 +158,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_individual_intensity(self, light_id: str, led_id: int) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        response: GetIndividualIntensityResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetIndividualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -180,7 +169,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_current_intensity(self, light_id: str) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        response: GetCurrentIntensityResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetCurrentIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -203,7 +192,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_angle_of_illumination(self, light_id: str) -> list[Range]:
         """List the valid angle of illumination values."""
-        response: GetValidAngleOfIlluminationResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetValidAngleOfIlluminationRequest(
                 api_version=self.api_version, light_id=light_id
             )
@@ -228,7 +217,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_angle_of_illumination(self, light_id: str) -> int:
         """Get the angle of illumination."""
-        response: GetManualAngleOfIlluminationResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetManualAngleOfIlluminationRequest(
                 api_version=self.api_version, light_id=light_id
             )
@@ -237,7 +226,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_current_angle_of_illumination(self, light_id: str) -> int:
         """Receive the current angle of illumination."""
-        response: GetCurrentAngleOfIlluminationResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetCurrentAngleOfIlluminationRequest(
                 api_version=self.api_version, light_id=light_id
             )
@@ -269,7 +258,5 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data

--- a/axis/interfaces/light_control.py
+++ b/axis/interfaces/light_control.py
@@ -80,25 +80,25 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def activate_light(self, light_id: str) -> None:
         """Activate the light."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             ActivateLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def deactivate_light(self, light_id: str) -> None:
         """Deactivate the light."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             DeactivateLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def enable_light(self, light_id: str) -> None:
         """Activate the light."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             EnableLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def disable_light(self, light_id: str) -> None:
         """Deactivate the light."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             DisableLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
@@ -111,7 +111,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def set_automatic_intensity_mode(self, light_id: str, enabled: bool) -> None:
         """Enable the automatic light intensity control."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetAutomaticIntensityModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -128,7 +128,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def set_manual_intensity(self, light_id: str, intensity: int) -> None:
         """Manually sets the intensity."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetManualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -147,7 +147,7 @@ class LightHandler(ApiHandler[LightInformation]):
         self, light_id: str, led_id: int, intensity: int
     ) -> None:
         """Manually sets the intensity for an individual LED."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetIndividualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -182,7 +182,7 @@ class LightHandler(ApiHandler[LightInformation]):
         Using this mode means that the angle of illumination
         is the same as the camera's angle of view.
         """
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetAutomaticAngleOfIlluminationModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -207,7 +207,7 @@ class LightHandler(ApiHandler[LightInformation]):
         This is useful when the angle of illumination needs
         to be different from the camera's view angle.
         """
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetManualAngleOfIlluminationModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -237,7 +237,7 @@ class LightHandler(ApiHandler[LightInformation]):
         self, light_id: str, enabled: bool
     ) -> None:
         """Enable automatic synchronization with the day/night mode."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetLightSynchronizeDayNightModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,

--- a/axis/interfaces/light_control.py
+++ b/axis/interfaces/light_control.py
@@ -77,52 +77,52 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_light_information(self) -> dict[str, LightInformation]:
         """List the light control information."""
-        response: GetLightInformationResponse = await self.vapix.api_request_typed(
+        response: GetLightInformationResponse = await self.vapix.api_request(
             GetLightInformationRequest(api_version=self.api_version)
         )
         return response.data
 
     async def get_service_capabilities(self) -> ServiceCapabilities:
         """List the light control information."""
-        response: GetServiceCapabilitiesResponse = await self.vapix.api_request_typed(
+        response: GetServiceCapabilitiesResponse = await self.vapix.api_request(
             GetServiceCapabilitiesRequest(api_version=self.api_version)
         )
         return response.data
 
     async def activate_light(self, light_id: str) -> None:
         """Activate the light."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             ActivateLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def deactivate_light(self, light_id: str) -> None:
         """Deactivate the light."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             DeactivateLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def enable_light(self, light_id: str) -> None:
         """Activate the light."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             EnableLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def disable_light(self, light_id: str) -> None:
         """Deactivate the light."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             DisableLightRequest(api_version=self.api_version, light_id=light_id)
         )
 
     async def get_light_status(self, light_id: str) -> bool:
         """Get light status if its on or off."""
-        response: GetLightStatusResponse = await self.vapix.api_request_typed(
+        response: GetLightStatusResponse = await self.vapix.api_request(
             GetLightStatusRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
 
     async def set_automatic_intensity_mode(self, light_id: str, enabled: bool) -> None:
         """Enable the automatic light intensity control."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetAutomaticIntensityModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -132,14 +132,14 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_intensity(self, light_id: str) -> Range:
         """Get valid intensity range for light."""
-        response: GetValidIntensityResponse = await self.vapix.api_request_typed(
+        response: GetValidIntensityResponse = await self.vapix.api_request(
             GetValidIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
 
     async def set_manual_intensity(self, light_id: str, intensity: int) -> None:
         """Manually sets the intensity."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetManualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -149,7 +149,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_intensity(self, light_id: str) -> int:
         """Enable the automatic light intensity control."""
-        response: GetManualIntensityResponse = await self.vapix.api_request_typed(
+        response: GetManualIntensityResponse = await self.vapix.api_request(
             GetManualIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -158,7 +158,7 @@ class LightHandler(ApiHandler[LightInformation]):
         self, light_id: str, led_id: int, intensity: int
     ) -> None:
         """Manually sets the intensity for an individual LED."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetIndividualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -169,7 +169,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_individual_intensity(self, light_id: str, led_id: int) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        response: GetIndividualIntensityResponse = await self.vapix.api_request_typed(
+        response: GetIndividualIntensityResponse = await self.vapix.api_request(
             GetIndividualIntensityRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -180,7 +180,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_current_intensity(self, light_id: str) -> int:
         """Receives the intensity from the setIndividualIntensity request."""
-        response: GetCurrentIntensityResponse = await self.vapix.api_request_typed(
+        response: GetCurrentIntensityResponse = await self.vapix.api_request(
             GetCurrentIntensityRequest(api_version=self.api_version, light_id=light_id)
         )
         return response.data
@@ -193,7 +193,7 @@ class LightHandler(ApiHandler[LightInformation]):
         Using this mode means that the angle of illumination
         is the same as the camera's angle of view.
         """
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetAutomaticAngleOfIlluminationModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -204,7 +204,7 @@ class LightHandler(ApiHandler[LightInformation]):
     async def get_valid_angle_of_illumination(self, light_id: str) -> list[Range]:
         """List the valid angle of illumination values."""
         response: GetValidAngleOfIlluminationResponse = (
-            await self.vapix.api_request_typed(
+            await self.vapix.api_request(
                 GetValidAngleOfIlluminationRequest(
                     api_version=self.api_version, light_id=light_id
                 )
@@ -220,7 +220,7 @@ class LightHandler(ApiHandler[LightInformation]):
         This is useful when the angle of illumination needs
         to be different from the camera's view angle.
         """
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetManualAngleOfIlluminationModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -231,7 +231,7 @@ class LightHandler(ApiHandler[LightInformation]):
     async def get_manual_angle_of_illumination(self, light_id: str) -> int:
         """Get the angle of illumination."""
         response: GetManualAngleOfIlluminationResponse = (
-            await self.vapix.api_request_typed(
+            await self.vapix.api_request(
                 GetManualAngleOfIlluminationRequest(
                     api_version=self.api_version, light_id=light_id
                 )
@@ -242,7 +242,7 @@ class LightHandler(ApiHandler[LightInformation]):
     async def get_current_angle_of_illumination(self, light_id: str) -> int:
         """Receive the current angle of illumination."""
         response: GetCurrentAngleOfIlluminationResponse = (
-            await self.vapix.api_request_typed(
+            await self.vapix.api_request(
                 GetCurrentAngleOfIlluminationRequest(
                     api_version=self.api_version, light_id=light_id
                 )
@@ -254,7 +254,7 @@ class LightHandler(ApiHandler[LightInformation]):
         self, light_id: str, enabled: bool
     ) -> None:
         """Enable automatic synchronization with the day/night mode."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetLightSynchronizeDayNightModeRequest(
                 api_version=self.api_version,
                 light_id=light_id,
@@ -265,7 +265,7 @@ class LightHandler(ApiHandler[LightInformation]):
     async def get_light_synchronization_day_night_mode(self, light_id: str) -> bool:
         """Check if the automatic synchronization is enabled with the day/night mode."""
         response: GetLightSynchronizeDayNightModeResponse = (
-            await self.vapix.api_request_typed(
+            await self.vapix.api_request(
                 GetLightSynchronizeDayNightModeRequest(
                     api_version=self.api_version, light_id=light_id
                 )
@@ -275,7 +275,7 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/light_control.py
+++ b/axis/interfaces/light_control.py
@@ -203,11 +203,9 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_valid_angle_of_illumination(self, light_id: str) -> list[Range]:
         """List the valid angle of illumination values."""
-        response: GetValidAngleOfIlluminationResponse = (
-            await self.vapix.api_request(
-                GetValidAngleOfIlluminationRequest(
-                    api_version=self.api_version, light_id=light_id
-                )
+        response: GetValidAngleOfIlluminationResponse = await self.vapix.api_request(
+            GetValidAngleOfIlluminationRequest(
+                api_version=self.api_version, light_id=light_id
             )
         )
         return response.data
@@ -230,22 +228,18 @@ class LightHandler(ApiHandler[LightInformation]):
 
     async def get_manual_angle_of_illumination(self, light_id: str) -> int:
         """Get the angle of illumination."""
-        response: GetManualAngleOfIlluminationResponse = (
-            await self.vapix.api_request(
-                GetManualAngleOfIlluminationRequest(
-                    api_version=self.api_version, light_id=light_id
-                )
+        response: GetManualAngleOfIlluminationResponse = await self.vapix.api_request(
+            GetManualAngleOfIlluminationRequest(
+                api_version=self.api_version, light_id=light_id
             )
         )
         return response.data
 
     async def get_current_angle_of_illumination(self, light_id: str) -> int:
         """Receive the current angle of illumination."""
-        response: GetCurrentAngleOfIlluminationResponse = (
-            await self.vapix.api_request(
-                GetCurrentAngleOfIlluminationRequest(
-                    api_version=self.api_version, light_id=light_id
-                )
+        response: GetCurrentAngleOfIlluminationResponse = await self.vapix.api_request(
+            GetCurrentAngleOfIlluminationRequest(
+                api_version=self.api_version, light_id=light_id
             )
         )
         return response.data

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -30,7 +30,7 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def configure_client(self, client_config: ClientConfig) -> None:
         """Configure MQTT Client."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             ConfigureClientRequest(
                 api_version=self.api_version, client_config=client_config
             )
@@ -38,13 +38,13 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def activate(self) -> None:
         """Activate MQTT Client."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             ActivateClientRequest(api_version=self.api_version)
         )
 
     async def deactivate(self) -> None:
         """Deactivate MQTT Client."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             DeactivateClientRequest(api_version=self.api_version)
         )
 
@@ -70,7 +70,7 @@ class MqttClientHandler(ApiHandler[Any]):
             [{"topicFilter": topic} for topic in topics]
         )
         config = EventPublicationConfig(event_filter_list=event_filters)
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             ConfigureEventPublicationRequest(
                 api_version=self.api_version, config=config
             )

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -32,7 +32,7 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def configure_client(self, client_config: ClientConfig) -> None:
         """Configure MQTT Client."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             ConfigureClientRequest(
                 api_version=self.api_version, client_config=client_config
             )
@@ -40,19 +40,19 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def activate(self) -> None:
         """Activate MQTT Client."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             ActivateClientRequest(api_version=self.api_version)
         )
 
     async def deactivate(self) -> None:
         """Deactivate MQTT Client."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             DeactivateClientRequest(api_version=self.api_version)
         )
 
     async def get_client_status(self) -> ClientConfigStatus:
         """Get MQTT Client status."""
-        response: GetClientStatusResponse = await self.vapix.api_request_typed(
+        response: GetClientStatusResponse = await self.vapix.api_request(
             GetClientStatusRequest(api_version=self.api_version)
         )
         return response.data
@@ -60,7 +60,7 @@ class MqttClientHandler(ApiHandler[Any]):
     async def get_event_publication_config(self) -> EventPublicationConfig:
         """Get MQTT Client event publication config."""
         response: GetEventPublicationConfigResponse = (
-            await self.vapix.api_request_typed(
+            await self.vapix.api_request(
                 GetEventPublicationConfigRequest(api_version=self.api_version)
             )
         )
@@ -74,7 +74,7 @@ class MqttClientHandler(ApiHandler[Any]):
             [{"topicFilter": topic} for topic in topics]
         )
         config = EventPublicationConfig(event_filter_list=event_filters)
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             ConfigureEventPublicationRequest(
                 api_version=self.api_version, config=config
             )

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -14,9 +14,7 @@ from ..models.mqtt import (
     EventFilter,
     EventPublicationConfig,
     GetClientStatusRequest,
-    GetClientStatusResponse,
     GetEventPublicationConfigRequest,
-    GetEventPublicationConfigResponse,
 )
 from .api_handler import ApiHandler, HandlerGroup
 
@@ -52,14 +50,14 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def get_client_status(self) -> ClientConfigStatus:
         """Get MQTT Client status."""
-        response: GetClientStatusResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetClientStatusRequest(api_version=self.api_version)
         )
         return response.data
 
     async def get_event_publication_config(self) -> EventPublicationConfig:
         """Get MQTT Client event publication config."""
-        response: GetEventPublicationConfigResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetEventPublicationConfigRequest(api_version=self.api_version)
         )
         return response.data

--- a/axis/interfaces/mqtt.py
+++ b/axis/interfaces/mqtt.py
@@ -59,10 +59,8 @@ class MqttClientHandler(ApiHandler[Any]):
 
     async def get_event_publication_config(self) -> EventPublicationConfig:
         """Get MQTT Client event publication config."""
-        response: GetEventPublicationConfigResponse = (
-            await self.vapix.api_request(
-                GetEventPublicationConfigRequest(api_version=self.api_version)
-            )
+        response: GetEventPublicationConfigResponse = await self.vapix.api_request(
+            GetEventPublicationConfigRequest(api_version=self.api_version)
         )
         return response.data
 

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -37,9 +37,7 @@ class Params(ApiHandler[Any]):
 
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
         """Fetch parameter data and convert it into a dictionary."""
-        response: ParamResponse = await self.vapix.api_request(
-            ParamRequest(group)
-        )
+        response: ParamResponse = await self.vapix.api_request(ParamRequest(group))
         return response.data
 
     async def _update(self, group: ParameterGroup | None = None) -> Sequence[str]:

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 from ...models.api_discovery import ApiId
-from ...models.parameters.param_cgi import ParameterGroup, ParamRequest, ParamResponse
+from ...models.parameters.param_cgi import ParameterGroup, ParamRequest
 from ..api_handler import ApiHandler
 from .brand import BrandParameterHandler
 from .image import ImageParameterHandler
@@ -37,7 +37,7 @@ class Params(ApiHandler[Any]):
 
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
         """Fetch parameter data and convert it into a dictionary."""
-        response: ParamResponse = await self.vapix.api_request(ParamRequest(group))
+        response = await self.vapix.api_request(ParamRequest(group))
         return response.data
 
     async def _update(self, group: ParameterGroup | None = None) -> Sequence[str]:

--- a/axis/interfaces/parameters/param_cgi.py
+++ b/axis/interfaces/parameters/param_cgi.py
@@ -37,7 +37,7 @@ class Params(ApiHandler[Any]):
 
     async def _api_request(self, group: ParameterGroup | None = None) -> dict[str, Any]:
         """Fetch parameter data and convert it into a dictionary."""
-        response: ParamResponse = await self.vapix.api_request_typed(
+        response: ParamResponse = await self.vapix.api_request(
             ParamRequest(group)
         )
         return response.data

--- a/axis/interfaces/pir_sensor_configuration.py
+++ b/axis/interfaces/pir_sensor_configuration.py
@@ -33,7 +33,7 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def list_sensors(self) -> dict[str, PirSensorConfiguration]:
         """List all PIR sensors of device."""
         api_version = self.api_version
-        response: ListSensorsResponse = await self.vapix.api_request_typed(
+        response: ListSensorsResponse = await self.vapix.api_request(
             ListSensorsRequest(api_version)
         )
         return response.data
@@ -41,7 +41,7 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def get_sensitivity(self, id: int) -> float | None:
         """Retrieve configured sensitivity of specific sensor."""
         api_version = self.api_version
-        response: GetSensitivityResponse = await self.vapix.api_request_typed(
+        response: GetSensitivityResponse = await self.vapix.api_request(
             GetSensitivityRequest(id, api_version)
         )
         return response.data
@@ -49,13 +49,13 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def set_sensitivity(self, id: int, sensitivity: float) -> None:
         """Configure sensitivity of specific sensor."""
         api_version = self.api_version
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetSensitivityRequest(id, sensitivity, api_version)
         )
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/pir_sensor_configuration.py
+++ b/axis/interfaces/pir_sensor_configuration.py
@@ -42,7 +42,7 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def set_sensitivity(self, id: int, sensitivity: float) -> None:
         """Configure sensitivity of specific sensor."""
         api_version = self.api_version
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetSensitivityRequest(id, sensitivity, api_version)
         )
 

--- a/axis/interfaces/pir_sensor_configuration.py
+++ b/axis/interfaces/pir_sensor_configuration.py
@@ -8,11 +8,8 @@ from ..models.api_discovery import ApiId
 from ..models.pir_sensor_configuration import (
     API_VERSION,
     GetSensitivityRequest,
-    GetSensitivityResponse,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     ListSensorsRequest,
-    ListSensorsResponse,
     PirSensorConfiguration,
     SetSensitivityRequest,
 )
@@ -33,17 +30,13 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
     async def list_sensors(self) -> dict[str, PirSensorConfiguration]:
         """List all PIR sensors of device."""
         api_version = self.api_version
-        response: ListSensorsResponse = await self.vapix.api_request(
-            ListSensorsRequest(api_version)
-        )
+        response = await self.vapix.api_request(ListSensorsRequest(api_version))
         return response.data
 
     async def get_sensitivity(self, id: int) -> float | None:
         """Retrieve configured sensitivity of specific sensor."""
         api_version = self.api_version
-        response: GetSensitivityResponse = await self.vapix.api_request(
-            GetSensitivityRequest(id, api_version)
-        )
+        response = await self.vapix.api_request(GetSensitivityRequest(id, api_version))
         return response.data
 
     async def set_sensitivity(self, id: int, sensitivity: float) -> None:
@@ -55,7 +48,5 @@ class PirSensorConfigurationHandler(ApiHandler[PirSensorConfiguration]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data

--- a/axis/interfaces/port_cgi.py
+++ b/axis/interfaces/port_cgi.py
@@ -44,7 +44,7 @@ class Ports(ApiHandler[IOPortParam]):
         """Activate or deactivate an output."""
         if (port := self[id]) and port.direction != PortDirection.OUT:
             return
-        await self.vapix._api_request_bytes(PortActionRequest(id, action))
+        await self.vapix.api_request(PortActionRequest(id, action))
 
     async def open(self, id: str) -> None:
         """Open port."""

--- a/axis/interfaces/port_cgi.py
+++ b/axis/interfaces/port_cgi.py
@@ -44,7 +44,7 @@ class Ports(ApiHandler[IOPortParam]):
         """Activate or deactivate an output."""
         if (port := self[id]) and port.direction != PortDirection.OUT:
             return
-        await self.vapix.api_request(PortActionRequest(id, action))
+        await self.vapix._api_request_bytes(PortActionRequest(id, action))
 
     async def open(self, id: str) -> None:
         """Open port."""

--- a/axis/interfaces/port_management.py
+++ b/axis/interfaces/port_management.py
@@ -8,9 +8,7 @@ from ..models.api_discovery import ApiId
 from ..models.port_management import (
     API_VERSION,
     GetPortsRequest,
-    GetPortsResponse,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     Port,
     PortConfiguration,
     Sequence,
@@ -33,7 +31,7 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_ports(self) -> dict[str, Port]:
         """List ports."""
-        response: GetPortsResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             GetPortsRequest(api_version=self.api_version)
         )
         return response.data
@@ -69,9 +67,7 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data
 
     async def open(self, port_id: str) -> None:

--- a/axis/interfaces/port_management.py
+++ b/axis/interfaces/port_management.py
@@ -51,13 +51,13 @@ class IoPortManagement(ApiHandler[Port]):
         Devices with configurable ports can change the direction
           to either input or output.
         """
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetPortsRequest(ports, api_version=self.api_version)
         )
 
     async def set_state_sequence(self, port_id: str, sequence: list[Sequence]) -> None:
         """Apply a sequence of state changes with a delay in milliseconds between states."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             SetStateSequenceRequest(
                 port_id,
                 sequence,

--- a/axis/interfaces/port_management.py
+++ b/axis/interfaces/port_management.py
@@ -33,7 +33,7 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_ports(self) -> dict[str, Port]:
         """List ports."""
-        response: GetPortsResponse = await self.vapix.api_request_typed(
+        response: GetPortsResponse = await self.vapix.api_request(
             GetPortsRequest(api_version=self.api_version)
         )
         return response.data
@@ -53,13 +53,13 @@ class IoPortManagement(ApiHandler[Port]):
         Devices with configurable ports can change the direction
           to either input or output.
         """
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetPortsRequest(ports, api_version=self.api_version)
         )
 
     async def set_state_sequence(self, port_id: str, sequence: list[Sequence]) -> None:
         """Apply a sequence of state changes with a delay in milliseconds between states."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             SetStateSequenceRequest(
                 port_id,
                 sequence,
@@ -69,7 +69,7 @@ class IoPortManagement(ApiHandler[Port]):
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/ptz.py
+++ b/axis/interfaces/ptz.py
@@ -72,7 +72,7 @@ class PtzControl(ApiHandler[PtzParam]):
         backlight: bool | None = None,
     ) -> None:
         """Control the pan, tilt and zoom behavior of a PTZ unit."""
-        await self.vapix._api_request_bytes(
+        await self.vapix.api_request(
             PtzControlRequest(
                 camera=camera,
                 center=center,
@@ -112,12 +112,12 @@ class PtzControl(ApiHandler[PtzParam]):
 
     async def query(self, query: PtzQuery) -> bytes:
         """Retrieve current status."""
-        return await self.vapix._api_request_bytes(QueryRequest(query))
+        return await self.vapix.api_request(QueryRequest(query))
 
     async def configured_device_driver(self) -> bytes:
         """Name of the system-configured device driver."""
-        return await self.vapix._api_request_bytes(DeviceDriverRequest())
+        return await self.vapix.api_request(DeviceDriverRequest())
 
     async def available_ptz_commands(self) -> bytes:
         """Available PTZ commands."""
-        return await self.vapix._api_request_bytes(PtzCommandRequest())
+        return await self.vapix.api_request(PtzCommandRequest())

--- a/axis/interfaces/ptz.py
+++ b/axis/interfaces/ptz.py
@@ -72,7 +72,7 @@ class PtzControl(ApiHandler[PtzParam]):
         backlight: bool | None = None,
     ) -> None:
         """Control the pan, tilt and zoom behavior of a PTZ unit."""
-        await self.vapix.api_request(
+        await self.vapix._api_request_bytes(
             PtzControlRequest(
                 camera=camera,
                 center=center,
@@ -112,12 +112,12 @@ class PtzControl(ApiHandler[PtzParam]):
 
     async def query(self, query: PtzQuery) -> bytes:
         """Retrieve current status."""
-        return await self.vapix.api_request(QueryRequest(query))
+        return await self.vapix._api_request_bytes(QueryRequest(query))
 
     async def configured_device_driver(self) -> bytes:
         """Name of the system-configured device driver."""
-        return await self.vapix.api_request(DeviceDriverRequest())
+        return await self.vapix._api_request_bytes(DeviceDriverRequest())
 
     async def available_ptz_commands(self) -> bytes:
         """Available PTZ commands."""
-        return await self.vapix.api_request(PtzCommandRequest())
+        return await self.vapix._api_request_bytes(PtzCommandRequest())

--- a/axis/interfaces/ptz.py
+++ b/axis/interfaces/ptz.py
@@ -112,12 +112,15 @@ class PtzControl(ApiHandler[PtzParam]):
 
     async def query(self, query: PtzQuery) -> bytes:
         """Retrieve current status."""
-        return await self.vapix.api_request(QueryRequest(query))
+        response = await self.vapix.api_request(QueryRequest(query))
+        return response.data
 
     async def configured_device_driver(self) -> bytes:
         """Name of the system-configured device driver."""
-        return await self.vapix.api_request(DeviceDriverRequest())
+        response = await self.vapix.api_request(DeviceDriverRequest())
+        return response.data
 
     async def available_ptz_commands(self) -> bytes:
         """Available PTZ commands."""
-        return await self.vapix.api_request(PtzCommandRequest())
+        response = await self.vapix.api_request(PtzCommandRequest())
+        return response.data

--- a/axis/interfaces/pwdgrp_cgi.py
+++ b/axis/interfaces/pwdgrp_cgi.py
@@ -55,7 +55,7 @@ class Users(ApiHandler[User]):
         comment: str | None = None,
     ) -> None:
         """Create new user."""
-        await self.vapix._api_request_bytes(CreateUserRequest(user, pwd, sgrp, comment))
+        await self.vapix.api_request(CreateUserRequest(user, pwd, sgrp, comment))
 
     async def modify(
         self,
@@ -66,8 +66,8 @@ class Users(ApiHandler[User]):
         comment: str | None = None,
     ) -> None:
         """Update user."""
-        await self.vapix._api_request_bytes(ModifyUserRequest(user, pwd, sgrp, comment))
+        await self.vapix.api_request(ModifyUserRequest(user, pwd, sgrp, comment))
 
     async def delete(self, user: str) -> None:
         """Remove user."""
-        await self.vapix._api_request_bytes(DeleteUserRequest(user))
+        await self.vapix.api_request(DeleteUserRequest(user))

--- a/axis/interfaces/pwdgrp_cgi.py
+++ b/axis/interfaces/pwdgrp_cgi.py
@@ -18,7 +18,6 @@ from ..models.pwdgrp_cgi import (
     CreateUserRequest,
     DeleteUserRequest,
     GetUsersRequest,
-    GetUsersResponse,
     ModifyUserRequest,
     SecondaryGroup,
     User,
@@ -44,7 +43,7 @@ class Users(ApiHandler[User]):
 
     async def list(self) -> dict[str, User]:
         """List current users."""
-        response: GetUsersResponse = await self.vapix.api_request(GetUsersRequest())
+        response = await self.vapix.api_request(GetUsersRequest())
         return response.data
 
     async def create(

--- a/axis/interfaces/pwdgrp_cgi.py
+++ b/axis/interfaces/pwdgrp_cgi.py
@@ -44,9 +44,7 @@ class Users(ApiHandler[User]):
 
     async def list(self) -> dict[str, User]:
         """List current users."""
-        response: GetUsersResponse = await self.vapix.api_request(
-            GetUsersRequest()
-        )
+        response: GetUsersResponse = await self.vapix.api_request(GetUsersRequest())
         return response.data
 
     async def create(

--- a/axis/interfaces/pwdgrp_cgi.py
+++ b/axis/interfaces/pwdgrp_cgi.py
@@ -44,7 +44,7 @@ class Users(ApiHandler[User]):
 
     async def list(self) -> dict[str, User]:
         """List current users."""
-        response: GetUsersResponse = await self.vapix.api_request_typed(
+        response: GetUsersResponse = await self.vapix.api_request(
             GetUsersRequest()
         )
         return response.data
@@ -58,7 +58,7 @@ class Users(ApiHandler[User]):
         comment: str | None = None,
     ) -> None:
         """Create new user."""
-        await self.vapix.api_request(CreateUserRequest(user, pwd, sgrp, comment))
+        await self.vapix._api_request_bytes(CreateUserRequest(user, pwd, sgrp, comment))
 
     async def modify(
         self,
@@ -69,8 +69,8 @@ class Users(ApiHandler[User]):
         comment: str | None = None,
     ) -> None:
         """Update user."""
-        await self.vapix.api_request(ModifyUserRequest(user, pwd, sgrp, comment))
+        await self.vapix._api_request_bytes(ModifyUserRequest(user, pwd, sgrp, comment))
 
     async def delete(self, user: str) -> None:
         """Remove user."""
-        await self.vapix.api_request(DeleteUserRequest(user))
+        await self.vapix._api_request_bytes(DeleteUserRequest(user))

--- a/axis/interfaces/stream_profiles.py
+++ b/axis/interfaces/stream_profiles.py
@@ -12,9 +12,7 @@ from ..models.api_discovery import ApiId
 from ..models.stream_profile import (
     API_VERSION,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     ListStreamProfilesRequest,
-    ListStreamProfilesResponse,
     StreamProfile,
 )
 from .api_handler import ApiHandler, HandlerGroup
@@ -33,14 +31,12 @@ class StreamProfilesHandler(ApiHandler[StreamProfile]):
 
     async def list_stream_profiles(self) -> dict[str, StreamProfile]:
         """List all stream profiles."""
-        response: ListStreamProfilesResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             ListStreamProfilesRequest(api_version=self.api_version)
         )
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data

--- a/axis/interfaces/stream_profiles.py
+++ b/axis/interfaces/stream_profiles.py
@@ -33,14 +33,14 @@ class StreamProfilesHandler(ApiHandler[StreamProfile]):
 
     async def list_stream_profiles(self) -> dict[str, StreamProfile]:
         """List all stream profiles."""
-        response: ListStreamProfilesResponse = await self.vapix.api_request_typed(
+        response: ListStreamProfilesResponse = await self.vapix.api_request(
             ListStreamProfilesRequest(api_version=self.api_version)
         )
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data

--- a/axis/interfaces/user_groups.py
+++ b/axis/interfaces/user_groups.py
@@ -17,7 +17,7 @@ class UserGroups(ApiHandler[User]):
 
     async def get_user_groups(self) -> dict[str, User]:
         """Retrieve privilege rights for current user."""
-        response: GetUserGroupResponse = await self.vapix.api_request_typed(
+        response: GetUserGroupResponse = await self.vapix.api_request(
             GetUserGroupRequest()
         )
         return response.data

--- a/axis/interfaces/user_groups.py
+++ b/axis/interfaces/user_groups.py
@@ -4,7 +4,7 @@ Figure out what access rights an account has.
 """
 
 from ..models.pwdgrp_cgi import User
-from ..models.user_group import GetUserGroupRequest, GetUserGroupResponse
+from ..models.user_group import GetUserGroupRequest
 from .api_handler import ApiHandler
 
 
@@ -17,7 +17,5 @@ class UserGroups(ApiHandler[User]):
 
     async def get_user_groups(self) -> dict[str, User]:
         """Retrieve privilege rights for current user."""
-        response: GetUserGroupResponse = await self.vapix.api_request(
-            GetUserGroupRequest()
-        )
+        response = await self.vapix.api_request(GetUserGroupRequest())
         return response.data

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -254,8 +254,8 @@ class Vapix:
             return
         self.user_groups._items.update(user_groups)
 
-    async def api_request(self, api_request: ApiRequest[Any]) -> bytes:
-        """Make a request to the device."""
+    async def _api_request_bytes(self, api_request: ApiRequest[Any]) -> bytes:
+        """Make a request to the device and return response bytes."""
         params = api_request.params or {}
         if self.device.config.is_companion:
             params["Axis-Orig-Sw"] = "true"
@@ -268,16 +268,16 @@ class Vapix:
             params=params,
         )
 
-    async def api_request_typed[ApiResponseT: ApiResponseBase](
+    async def api_request[ApiResponseT: ApiResponseBase](
         self,
         api_request: ApiRequest[ApiResponseT],
     ) -> ApiResponseT:
-        """Make a request and decode response using the typed response contract."""
+        """Make a request and decode response using request response metadata."""
         if api_request.response_type is None:
-            msg = "No response type configured on request; set request.response_type"
+            msg = "No response type configured on request; use _api_request_bytes"
             raise ValueError(msg)
 
-        bytes_data = await self.api_request(api_request)
+        bytes_data = await self._api_request_bytes(api_request)
         decoder = cast("type[ApiResponseT]", api_request.response_type)
         return decoder.decode(bytes_data)
 

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -270,7 +270,7 @@ class Vapix:
 
     async def api_request_typed[ApiResponseT: ApiResponseBase](
         self,
-        api_request: ApiRequest,
+        api_request: ApiRequest[ApiResponseT],
     ) -> ApiResponseT:
         """Make a request and decode response using the typed response contract."""
         if api_request.response_type is None:

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
@@ -34,7 +34,7 @@ from .view_areas import ViewAreaHandler
 
 if TYPE_CHECKING:
     from ..device import AxisDevice
-    from ..models.api import ApiRequest, ApiResponseBase
+    from ..models.api import ApiRequest
     from ..models.stream_profile import StreamProfile
 
 LOGGER = logging.getLogger(__name__)
@@ -254,12 +254,15 @@ class Vapix:
             return
         self.user_groups._items.update(user_groups)
 
-    async def _api_request_bytes(self, api_request: ApiRequest[Any]) -> bytes:
-        """Make a request to the device and return response bytes."""
+    async def api_request[ApiResponseT](
+        self,
+        api_request: ApiRequest[ApiResponseT],
+    ) -> ApiResponseT:
+        """Make a request and decode response based on the request contract."""
         params = api_request.params or {}
         if self.device.config.is_companion:
             params["Axis-Orig-Sw"] = "true"
-        return await self.request(
+        bytes_data = await self.request(
             method=api_request.method,
             path=api_request.path,
             content=api_request.content,
@@ -268,17 +271,7 @@ class Vapix:
             params=params,
         )
 
-    async def api_request[ApiResponseT: ApiResponseBase](
-        self,
-        api_request: ApiRequest[ApiResponseT],
-    ) -> ApiResponseT:
-        """Make a request and decode response using request response metadata."""
-        if api_request.response_type is None:
-            msg = "No response type configured on request; use _api_request_bytes"
-            raise ValueError(msg)
-
-        bytes_data = await self._api_request_bytes(api_request)
-        decoder = cast("type[ApiResponseT]", api_request.response_type)
+        decoder = api_request.response_type
         return decoder.decode(bytes_data)
 
     async def request(

--- a/axis/interfaces/vapix.py
+++ b/axis/interfaces/vapix.py
@@ -254,7 +254,7 @@ class Vapix:
             return
         self.user_groups._items.update(user_groups)
 
-    async def api_request(self, api_request: ApiRequest) -> bytes:
+    async def api_request(self, api_request: ApiRequest[Any]) -> bytes:
         """Make a request to the device."""
         params = api_request.params or {}
         if self.device.config.is_companion:

--- a/axis/interfaces/view_areas.py
+++ b/axis/interfaces/view_areas.py
@@ -13,9 +13,7 @@ from ..models.view_area import (
     Geometry,
     GetSupportedConfigVersionsRequest,
     GetSupportedVersionsRequest,
-    GetSupportedVersionsResponse,
     ListViewAreasRequest,
-    ListViewAreasResponse,
     ResetGeometryRequest,
     SetGeometryRequest,
     ViewArea,
@@ -36,9 +34,7 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
 
     async def list_view_areas(self) -> dict[str, ViewArea]:
         """List all view areas of device."""
-        response: ListViewAreasResponse = await self.vapix.api_request(
-            ListViewAreasRequest(self.api_version)
-        )
+        response = await self.vapix.api_request(ListViewAreasRequest(self.api_version))
         return response.data
 
     async def set_geometry(self, id: int, geometry: Geometry) -> dict[str, ViewArea]:
@@ -47,7 +43,7 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        response: ListViewAreasResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             SetGeometryRequest(
                 id=id,
                 geometry=geometry,
@@ -62,21 +58,17 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        response: ListViewAreasResponse = await self.vapix.api_request(
+        response = await self.vapix.api_request(
             ResetGeometryRequest(id=id, api_version=self.api_version)
         )
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedVersionsRequest())
         return response.data
 
     async def get_supported_config_versions(self) -> list[str]:
         """List supported configure API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request(
-            GetSupportedConfigVersionsRequest()
-        )
+        response = await self.vapix.api_request(GetSupportedConfigVersionsRequest())
         return response.data

--- a/axis/interfaces/view_areas.py
+++ b/axis/interfaces/view_areas.py
@@ -36,7 +36,7 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
 
     async def list_view_areas(self) -> dict[str, ViewArea]:
         """List all view areas of device."""
-        response: ListViewAreasResponse = await self.vapix.api_request_typed(
+        response: ListViewAreasResponse = await self.vapix.api_request(
             ListViewAreasRequest(self.api_version)
         )
         return response.data
@@ -47,7 +47,7 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        response: ListViewAreasResponse = await self.vapix.api_request_typed(
+        response: ListViewAreasResponse = await self.vapix.api_request(
             SetGeometryRequest(
                 id=id,
                 geometry=geometry,
@@ -62,21 +62,21 @@ class ViewAreaHandler(ApiHandler[ViewArea]):
         Security level: Admin
         Method: POST
         """
-        response: ListViewAreasResponse = await self.vapix.api_request_typed(
+        response: ListViewAreasResponse = await self.vapix.api_request(
             ResetGeometryRequest(id=id, api_version=self.api_version)
         )
         return response.data
 
     async def get_supported_versions(self) -> list[str]:
         """List supported API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedVersionsRequest()
         )
         return response.data
 
     async def get_supported_config_versions(self) -> list[str]:
         """List supported configure API versions."""
-        response: GetSupportedVersionsResponse = await self.vapix.api_request_typed(
+        response: GetSupportedVersionsResponse = await self.vapix.api_request(
             GetSupportedConfigVersionsRequest()
         )
         return response.data

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -62,10 +62,7 @@ class BytesResponse(ApiResponse[bytes]):
 
 @dataclass
 class ApiRequest[ResponseT = ApiResponse[bytes]]:
-    """Create API request body with typed response contract.
-
-    Subclasses must set ``response_type`` to the decoder for ``ResponseT``.
-    """
+    """Create API request body with typed response contract."""
 
     method: str = field(init=False)
     path: str = field(init=False)

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Protocol, Self, cast
+from typing import Any, ClassVar, Protocol, Self
 
 CONTEXT = "Axis library"
 
@@ -50,25 +50,27 @@ class ApiResponse[ApiDataT](ABC):
         """Decode data to class object."""
 
 
-class BytesResponse(ApiResponseDecoder[bytes]):
-    """Decoder that keeps the response payload as raw bytes."""
+@dataclass
+class BytesResponse(ApiResponse[bytes]):
+    """Response wrapper for APIs that only return raw bytes."""
 
     @classmethod
-    def decode(cls, bytes_data: bytes) -> bytes:
-        """Return raw response payload bytes unchanged."""
-        return bytes_data
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Wrap raw response payload bytes in an ApiResponse object."""
+        return cls(data=bytes_data)
 
 
 @dataclass
-class ApiRequest[ResponseT = bytes]:
-    """Create API request body with typed response contract."""
+class ApiRequest[ResponseT = ApiResponse[bytes]]:
+    """Create API request body with typed response contract.
+
+    Subclasses must set ``response_type`` to the decoder for ``ResponseT``.
+    """
 
     method: str = field(init=False)
     path: str = field(init=False)
     content_type: str = field(init=False)
-    response_type: ClassVar[type[ApiResponseDecoder[ResponseT]]] = cast(
-        "type[ApiResponseDecoder[ResponseT]]", BytesResponse
-    )
+    response_type: ClassVar[type[ApiResponseDecoder[ResponseT]]]
 
     @property
     def content(self) -> bytes | None:

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -38,8 +38,11 @@ class ApiResponseDecoder[DecodedT](Protocol):
 
 
 @dataclass
-class ApiResponseBase(ABC):
+class ApiResponse[ApiDataT](ABC):
     """Response from API request."""
+
+    data: ApiDataT
+    # error: str
 
     @classmethod
     @abstractmethod
@@ -54,14 +57,6 @@ class BytesResponse(ApiResponseDecoder[bytes]):
     def decode(cls, bytes_data: bytes) -> bytes:
         """Return raw response payload bytes unchanged."""
         return bytes_data
-
-
-@dataclass
-class ApiResponse[ApiDataT](ApiResponseBase):
-    """Response from API request."""
-
-    data: ApiDataT
-    # error: str
 
 
 @dataclass

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -48,8 +48,8 @@ class ApiResponse[ApiDataT](ApiResponseBase):
 
 
 @dataclass
-class ApiRequest:
-    """Create API request body."""
+class ApiRequest[ResponseT: ApiResponseBase]:
+    """Create API request body with typed response contract."""
 
     method: str = field(init=False)
     path: str = field(init=False)

--- a/axis/models/api.py
+++ b/axis/models/api.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Protocol, Self, cast
 
 CONTEXT = "Axis library"
 
@@ -29,6 +29,14 @@ class ApiItem(ABC):
         return {v.id: v for v in cls.decode_to_list(data)}
 
 
+class ApiResponseDecoder[DecodedT](Protocol):
+    """Decoder contract for API request responses."""
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> DecodedT:
+        """Decode raw bytes into a typed response payload."""
+
+
 @dataclass
 class ApiResponseBase(ABC):
     """Response from API request."""
@@ -37,6 +45,15 @@ class ApiResponseBase(ABC):
     @abstractmethod
     def decode(cls, bytes_data: bytes) -> Self:
         """Decode data to class object."""
+
+
+class BytesResponse(ApiResponseDecoder[bytes]):
+    """Decoder that keeps the response payload as raw bytes."""
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> bytes:
+        """Return raw response payload bytes unchanged."""
+        return bytes_data
 
 
 @dataclass
@@ -48,13 +65,15 @@ class ApiResponse[ApiDataT](ApiResponseBase):
 
 
 @dataclass
-class ApiRequest[ResponseT: ApiResponseBase]:
+class ApiRequest[ResponseT = bytes]:
     """Create API request body with typed response contract."""
 
     method: str = field(init=False)
     path: str = field(init=False)
     content_type: str = field(init=False)
-    response_type: ClassVar[type[ApiResponseBase] | None] = None
+    response_type: ClassVar[type[ApiResponseDecoder[ResponseT]]] = cast(
+        "type[ApiResponseDecoder[ResponseT]]", BytesResponse
+    )
 
     @property
     def content(self) -> bytes | None:

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Never, NotRequired, Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 import orjson
 

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -1,9 +1,12 @@
 """API Discovery api item."""
 
+from __future__ import annotations
+
+
 from dataclasses import dataclass
 import enum
 import logging
-from typing import NotRequired, Self, TypedDict
+from typing import Never, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -16,8 +19,6 @@ LOGGER = logging.getLogger(__name__)
 
 class ApiId(enum.StrEnum):
     """The API discovery ID."""
-from __future__ import annotations
-
 
     AIR_QUALITY = "airquality"
     ANALYTICS_METADATA_CONFIG = "analytics-metadata-config"

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -1,7 +1,5 @@
 """API Discovery api item."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 import logging

--- a/axis/models/api_discovery.py
+++ b/axis/models/api_discovery.py
@@ -16,6 +16,8 @@ LOGGER = logging.getLogger(__name__)
 
 class ApiId(enum.StrEnum):
     """The API discovery ID."""
+from __future__ import annotations
+
 
     AIR_QUALITY = "airquality"
     ANALYTICS_METADATA_CONFIG = "analytics-metadata-config"
@@ -222,7 +224,7 @@ class GetAllApisResponse(ApiResponse[dict[str, Api]]):
 
 
 @dataclass
-class ListApisRequest(ApiRequest):
+class ListApisRequest(ApiRequest[GetAllApisResponse]):
     """Request object for listing API descriptions."""
 
     method = "post"
@@ -269,7 +271,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Literal, NotRequired, Self, TypedDict
+from typing import Never, Literal, NotRequired, Self, TypedDict
 
 import xmltodict
 

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -6,10 +6,9 @@ and their license keys.
 
 from __future__ import annotations
 
-
 from dataclasses import dataclass
 import enum
-from typing import Never, Literal, NotRequired, Self, TypedDict
+from typing import Literal, NotRequired, Self, TypedDict
 
 import xmltodict
 

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -4,6 +4,9 @@ Use VAPIX® Application API to upload, control and manage applications
 and their license keys.
 """
 
+from __future__ import annotations
+
+
 from dataclasses import dataclass
 import enum
 from typing import Literal, NotRequired, Self, TypedDict
@@ -160,7 +163,7 @@ class ListApplicationsResponse(ApiResponse[dict[str, Application]]):
 
 
 @dataclass
-class ListApplicationsRequest(ApiRequest):
+class ListApplicationsRequest(ApiRequest[ListApplicationsResponse]):
     """Request object for listing installed applications."""
 
     method = "post"

--- a/axis/models/applications/application.py
+++ b/axis/models/applications/application.py
@@ -4,8 +4,6 @@ Use VAPIX® Application API to upload, control and manage applications
 and their license keys.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 from typing import Literal, NotRequired, Self, TypedDict

--- a/axis/models/applications/fence_guard.py
+++ b/axis/models/applications/fence_guard.py
@@ -134,7 +134,7 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
+class GetConfigurationRequest(ApiRequest[GetConfigurationResponse]):
     """Request object for listing Fence guard configuration."""
 
     method = "post"

--- a/axis/models/applications/loitering_guard.py
+++ b/axis/models/applications/loitering_guard.py
@@ -134,7 +134,7 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
+class GetConfigurationRequest(ApiRequest[GetConfigurationResponse]):
     """Request object for listing Loitering guard configuration."""
 
     method = "post"

--- a/axis/models/applications/motion_guard.py
+++ b/axis/models/applications/motion_guard.py
@@ -134,7 +134,7 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
+class GetConfigurationRequest(ApiRequest[GetConfigurationResponse]):
     """Request object for listing Motion guard configuration."""
 
     method = "post"

--- a/axis/models/applications/object_analytics.py
+++ b/axis/models/applications/object_analytics.py
@@ -197,7 +197,7 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
+class GetConfigurationRequest(ApiRequest[GetConfigurationResponse]):
     """Request object for listing Object analytics configuration."""
 
     method = "post"

--- a/axis/models/applications/vmd4.py
+++ b/axis/models/applications/vmd4.py
@@ -129,7 +129,7 @@ class GetConfigurationResponse(ApiResponse[Configuration]):
 
 
 @dataclass
-class GetConfigurationRequest(ApiRequest):
+class GetConfigurationRequest(ApiRequest[GetConfigurationResponse]):
     """Request object for listing VMD4 configuration."""
 
     method = "post"

--- a/axis/models/basic_device_info.py
+++ b/axis/models/basic_device_info.py
@@ -144,7 +144,7 @@ class GetAllPropertiesResponse(ApiResponse[DeviceInformation]):
 
 
 @dataclass
-class GetAllPropertiesRequest(ApiRequest):
+class GetAllPropertiesRequest(ApiRequest[GetAllPropertiesResponse]):
     """Request object for basic device info."""
 
     method = "post"
@@ -191,7 +191,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import enum
-from typing import Any, Self
+from typing import Never, Any, Self
 
 import xmltodict
 

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -1,7 +1,5 @@
 """Event service and action service APIs available in Axis network device."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 from typing import Any, Self

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -1,8 +1,10 @@
 """Event service and action service APIs available in Axis network device."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import enum
-from typing import Never, Any, Self
+from typing import Any, Self
 
 import xmltodict
 
@@ -39,11 +41,9 @@ NAMESPACES = {
 
 def get_events(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Get all events.
-    from __future__ import annotations
 
-
-        Ignore keys with "@" while traversing structure. Indicates an attribute in value.
-        When @topic is reached, return event data and build topic structure.
+    Ignore keys with "@" while traversing structure. Indicates an attribute in value.
+    When @topic is reached, return event data and build topic structure.
     """
     events = []
     for key, value in data.items():

--- a/axis/models/event_instance.py
+++ b/axis/models/event_instance.py
@@ -39,9 +39,11 @@ NAMESPACES = {
 
 def get_events(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Get all events.
+    from __future__ import annotations
 
-    Ignore keys with "@" while traversing structure. Indicates an attribute in value.
-    When @topic is reached, return event data and build topic structure.
+
+        Ignore keys with "@" while traversing structure. Indicates an attribute in value.
+        When @topic is reached, return event data and build topic structure.
     """
     events = []
     for key, value in data.items():
@@ -391,7 +393,7 @@ class ListEventInstancesResponse(ApiResponse[dict[str, Any]]):
 
 
 @dataclass
-class ListEventInstancesRequest(ApiRequest):
+class ListEventInstancesRequest(ApiRequest[ListEventInstancesResponse]):
     """Request object for listing installed applications."""
 
     method = "post"

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -5,7 +5,7 @@ from typing import NotRequired, Self, TypedDict
 
 import orjson
 
-from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
+from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse, BytesResponse
 
 API_VERSION = "1.1"
 
@@ -359,12 +359,13 @@ class GetServiceCapabilitiesRequest(ApiRequest[GetServiceCapabilitiesResponse]):
 
 
 @dataclass
-class ActivateLightRequest(ApiRequest[bytes]):
+class ActivateLightRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for activating light."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -487,12 +488,13 @@ class GetLightStatusRequest(ApiRequest[GetLightStatusResponse]):
 
 
 @dataclass
-class SetAutomaticIntensityModeRequest(ApiRequest[bytes]):
+class SetAutomaticIntensityModeRequest(ApiRequest[ApiResponse[bytes]]):
     """Enable the automatic light intensity control."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -565,12 +567,13 @@ class GetValidIntensityRequest(ApiRequest[GetValidIntensityResponse]):
 
 
 @dataclass
-class SetManualIntensityRequest(ApiRequest[bytes]):
+class SetManualIntensityRequest(ApiRequest[ApiResponse[bytes]]):
     """Set manual light intensity."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -643,12 +646,13 @@ class GetManualIntensityRequest(ApiRequest[GetManualIntensityResponse]):
 
 
 @dataclass
-class SetIndividualIntensityRequest(ApiRequest[bytes]):
+class SetIndividualIntensityRequest(ApiRequest[ApiResponse[bytes]]):
     """Set individual light intensity."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -777,12 +781,13 @@ class GetCurrentIntensityRequest(ApiRequest[GetCurrentIntensityResponse]):
 
 
 @dataclass
-class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest[bytes]):
+class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest[ApiResponse[bytes]]):
     """Enable the automatic angle of illumination control."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -857,12 +862,13 @@ class GetValidAngleOfIlluminationRequest(
 
 
 @dataclass
-class SetManualAngleOfIlluminationModeRequest(ApiRequest[bytes]):
+class SetManualAngleOfIlluminationModeRequest(ApiRequest[ApiResponse[bytes]]):
     """Set the manual angle of illumination."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str
@@ -992,12 +998,13 @@ class GetCurrentAngleOfIlluminationRequest(
 
 
 @dataclass
-class SetLightSynchronizeDayNightModeRequest(ApiRequest[bytes]):
+class SetLightSynchronizeDayNightModeRequest(ApiRequest[ApiResponse[bytes]]):
     """Enable automatic synchronization with the day/night mode."""
 
     method = "post"
     path = "/axis-cgi/lightcontrol.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     light_id: str

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -1,7 +1,7 @@
 """Light Control API data model."""
 
 from dataclasses import dataclass
-from typing import Never, NotRequired, Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 import orjson
 
@@ -359,7 +359,7 @@ class GetServiceCapabilitiesRequest(ApiRequest[GetServiceCapabilitiesResponse]):
 
 
 @dataclass
-class ActivateLightRequest(ApiRequest[Never]):
+class ActivateLightRequest(ApiRequest[bytes]):
     """Request object for activating light."""
 
     method = "post"
@@ -487,7 +487,7 @@ class GetLightStatusRequest(ApiRequest[GetLightStatusResponse]):
 
 
 @dataclass
-class SetAutomaticIntensityModeRequest(ApiRequest[Never]):
+class SetAutomaticIntensityModeRequest(ApiRequest[bytes]):
     """Enable the automatic light intensity control."""
 
     method = "post"
@@ -565,7 +565,7 @@ class GetValidIntensityRequest(ApiRequest[GetValidIntensityResponse]):
 
 
 @dataclass
-class SetManualIntensityRequest(ApiRequest[Never]):
+class SetManualIntensityRequest(ApiRequest[bytes]):
     """Set manual light intensity."""
 
     method = "post"
@@ -643,7 +643,7 @@ class GetManualIntensityRequest(ApiRequest[GetManualIntensityResponse]):
 
 
 @dataclass
-class SetIndividualIntensityRequest(ApiRequest[Never]):
+class SetIndividualIntensityRequest(ApiRequest[bytes]):
     """Set individual light intensity."""
 
     method = "post"
@@ -777,7 +777,7 @@ class GetCurrentIntensityRequest(ApiRequest[GetCurrentIntensityResponse]):
 
 
 @dataclass
-class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest[Never]):
+class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest[bytes]):
     """Enable the automatic angle of illumination control."""
 
     method = "post"
@@ -857,7 +857,7 @@ class GetValidAngleOfIlluminationRequest(
 
 
 @dataclass
-class SetManualAngleOfIlluminationModeRequest(ApiRequest[Never]):
+class SetManualAngleOfIlluminationModeRequest(ApiRequest[bytes]):
     """Set the manual angle of illumination."""
 
     method = "post"
@@ -992,7 +992,7 @@ class GetCurrentAngleOfIlluminationRequest(
 
 
 @dataclass
-class SetLightSynchronizeDayNightModeRequest(ApiRequest[Never]):
+class SetLightSynchronizeDayNightModeRequest(ApiRequest[bytes]):
     """Enable automatic synchronization with the day/night mode."""
 
     method = "post"

--- a/axis/models/light_control.py
+++ b/axis/models/light_control.py
@@ -1,7 +1,7 @@
 """Light Control API data model."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self, TypedDict
+from typing import Never, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -257,7 +257,7 @@ class GetLightInformationResponse(ApiResponse[dict[str, LightInformation]]):
 
 
 @dataclass
-class GetLightInformationRequest(ApiRequest):
+class GetLightInformationRequest(ApiRequest[GetLightInformationResponse]):
     """Request object for getting light information."""
 
     method = "post"
@@ -334,7 +334,7 @@ class GetServiceCapabilitiesResponse(ApiResponse[ServiceCapabilities]):
 
 
 @dataclass
-class GetServiceCapabilitiesRequest(ApiRequest):
+class GetServiceCapabilitiesRequest(ApiRequest[GetServiceCapabilitiesResponse]):
     """Request object for getting service capabilities."""
 
     method = "post"
@@ -359,7 +359,7 @@ class GetServiceCapabilitiesRequest(ApiRequest):
 
 
 @dataclass
-class ActivateLightRequest(ApiRequest):
+class ActivateLightRequest(ApiRequest[Never]):
     """Request object for activating light."""
 
     method = "post"
@@ -459,7 +459,7 @@ class GetLightStatusResponse(ApiResponse[bool]):
 
 
 @dataclass
-class GetLightStatusRequest(ApiRequest):
+class GetLightStatusRequest(ApiRequest[GetLightStatusResponse]):
     """Request object for getting light status."""
 
     method = "post"
@@ -487,7 +487,7 @@ class GetLightStatusRequest(ApiRequest):
 
 
 @dataclass
-class SetAutomaticIntensityModeRequest(ApiRequest):
+class SetAutomaticIntensityModeRequest(ApiRequest[Never]):
     """Enable the automatic light intensity control."""
 
     method = "post"
@@ -537,7 +537,7 @@ class GetValidIntensityResponse(ApiResponse[Range]):
 
 
 @dataclass
-class GetValidIntensityRequest(ApiRequest):
+class GetValidIntensityRequest(ApiRequest[GetValidIntensityResponse]):
     """Request object for getting valid intensity range of light."""
 
     method = "post"
@@ -565,7 +565,7 @@ class GetValidIntensityRequest(ApiRequest):
 
 
 @dataclass
-class SetManualIntensityRequest(ApiRequest):
+class SetManualIntensityRequest(ApiRequest[Never]):
     """Set manual light intensity."""
 
     method = "post"
@@ -615,7 +615,7 @@ class GetManualIntensityResponse(ApiResponse[int]):
 
 
 @dataclass
-class GetManualIntensityRequest(ApiRequest):
+class GetManualIntensityRequest(ApiRequest[GetManualIntensityResponse]):
     """Request object for getting manual intensity."""
 
     method = "post"
@@ -643,7 +643,7 @@ class GetManualIntensityRequest(ApiRequest):
 
 
 @dataclass
-class SetIndividualIntensityRequest(ApiRequest):
+class SetIndividualIntensityRequest(ApiRequest[Never]):
     """Set individual light intensity."""
 
     method = "post"
@@ -698,7 +698,7 @@ class GetIndividualIntensityResponse(ApiResponse[int]):
 
 
 @dataclass
-class GetIndividualIntensityRequest(ApiRequest):
+class GetIndividualIntensityRequest(ApiRequest[GetIndividualIntensityResponse]):
     """Request object for getting individual intensity."""
 
     method = "post"
@@ -749,7 +749,7 @@ class GetCurrentIntensityResponse(ApiResponse[int]):
 
 
 @dataclass
-class GetCurrentIntensityRequest(ApiRequest):
+class GetCurrentIntensityRequest(ApiRequest[GetCurrentIntensityResponse]):
     """Request object for getting current intensity."""
 
     method = "post"
@@ -777,7 +777,7 @@ class GetCurrentIntensityRequest(ApiRequest):
 
 
 @dataclass
-class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest):
+class SetAutomaticAngleOfIlluminationModeRequest(ApiRequest[Never]):
     """Enable the automatic angle of illumination control."""
 
     method = "post"
@@ -827,7 +827,9 @@ class GetValidAngleOfIlluminationResponse(ApiResponse[list[Range]]):
 
 
 @dataclass
-class GetValidAngleOfIlluminationRequest(ApiRequest):
+class GetValidAngleOfIlluminationRequest(
+    ApiRequest[GetValidAngleOfIlluminationResponse]
+):
     """Request object for getting valid angle of illumination range."""
 
     method = "post"
@@ -855,7 +857,7 @@ class GetValidAngleOfIlluminationRequest(ApiRequest):
 
 
 @dataclass
-class SetManualAngleOfIlluminationModeRequest(ApiRequest):
+class SetManualAngleOfIlluminationModeRequest(ApiRequest[Never]):
     """Set the manual angle of illumination."""
 
     method = "post"
@@ -908,7 +910,9 @@ class GetManualAngleOfIlluminationResponse(ApiResponse[int]):
 
 
 @dataclass
-class GetManualAngleOfIlluminationRequest(ApiRequest):
+class GetManualAngleOfIlluminationRequest(
+    ApiRequest[GetManualAngleOfIlluminationResponse]
+):
     """Request object for getting manual angle of illumination."""
 
     method = "post"
@@ -958,7 +962,9 @@ class GetCurrentAngleOfIlluminationResponse(ApiResponse[int]):
 
 
 @dataclass
-class GetCurrentAngleOfIlluminationRequest(ApiRequest):
+class GetCurrentAngleOfIlluminationRequest(
+    ApiRequest[GetCurrentAngleOfIlluminationResponse]
+):
     """Request object for getting current angle of illumination."""
 
     method = "post"
@@ -986,7 +992,7 @@ class GetCurrentAngleOfIlluminationRequest(ApiRequest):
 
 
 @dataclass
-class SetLightSynchronizeDayNightModeRequest(ApiRequest):
+class SetLightSynchronizeDayNightModeRequest(ApiRequest[Never]):
     """Enable automatic synchronization with the day/night mode."""
 
     method = "post"
@@ -1036,7 +1042,9 @@ class GetLightSynchronizeDayNightModeResponse(ApiResponse[bool]):
 
 
 @dataclass
-class GetLightSynchronizeDayNightModeRequest(ApiRequest):
+class GetLightSynchronizeDayNightModeRequest(
+    ApiRequest[GetLightSynchronizeDayNightModeResponse]
+):
     """Request object for getting day night mode synchronization setting."""
 
     method = "post"
@@ -1086,7 +1094,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -195,255 +195,6 @@ class ServerProtocol(enum.StrEnum):
 
 
 @dataclass
-class ClientConfigStatus:
-    """GetClientStatus response."""
-
-    config: ClientConfig
-    """The Config of the MQTT client."""
-    status: ClientStatus
-    """The Status of the MQTT client."""
-
-    @classmethod
-    def from_dict(cls, data: ClientStatusDataT) -> Self:
-        """Create client config status object from dict."""
-        return cls(
-            config=ClientConfig.from_dict(data["config"]),
-            status=ClientStatus.from_dict(data["status"]),
-        )
-
-
-@dataclass
-class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
-    """Response object for get client status request."""
-
-    api_version: str
-    context: str
-    method: str
-    data: ClientConfigStatus
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare response data."""
-        data: GetClientStatusResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=ClientConfigStatus.from_dict(data["data"]),
-        )
-
-
-@dataclass
-class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
-    """Request object for configuring MQTT client."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    client_config: ClientConfig
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "configureClient",
-                "params": self.client_config.to_dict(),
-            }
-        )
-
-
-@dataclass
-class ActivateClientRequest(ApiRequest[Never]):
-    """Request object for activating MQTT client."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "activateClient",
-            }
-        )
-
-
-@dataclass
-class DeactivateClientRequest(ActivateClientRequest):
-    """Request object for deactivating MQTT client."""
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "deactivateClient",
-            }
-        )
-
-
-@dataclass
-class GetClientStatusRequest(ApiRequest):
-    """Request object for getting MQTT client status."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    response_type = GetClientStatusResponse
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getClientStatus",
-            }
-        )
-
-
-@dataclass
-class EventPublicationConfig:
-    """Event publication config."""
-
-    topic_prefix: str | None = None
-    custom_topic_prefix: str | None = None
-    append_event_topic: bool | None = None
-    include_topic_namespaces: bool | None = None
-    include_serial_number_in_payload: bool | None = None
-    event_filter_list: list[EventFilter] | None = None
-
-    @classmethod
-    def from_dict(cls, data: EventPublicationConfigT) -> Self:
-        """Create client config status object from dict."""
-        return cls(
-            topic_prefix=data["topicPrefix"],
-            custom_topic_prefix=data["customTopicPrefix"],
-            append_event_topic=data["appendEventTopic"],
-            include_topic_namespaces=data["includeTopicNamespaces"],
-            include_serial_number_in_payload=data["includeSerialNumberInPayload"],
-            event_filter_list=EventFilter.from_list(data["eventFilterList"]),
-        )
-
-    def to_dict(self) -> EventPublicationConfigT:
-        """Create json dict from object."""
-        data: EventPublicationConfigT = {}
-        if self.topic_prefix is not None:
-            data["topicPrefix"] = self.topic_prefix
-        if self.custom_topic_prefix is not None:
-            data["customTopicPrefix"] = self.custom_topic_prefix
-        if self.append_event_topic is not None:
-            data["appendEventTopic"] = self.append_event_topic
-        if self.include_topic_namespaces is not None:
-            data["includeTopicNamespaces"] = self.include_topic_namespaces
-        if self.include_serial_number_in_payload is not None:
-            data["includeSerialNumberInPayload"] = self.include_serial_number_in_payload
-        if self.event_filter_list is not None:
-            data["eventFilterList"] = EventFilter.to_list(self.event_filter_list)
-        return data
-
-
-@dataclass
-class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
-    """Response object for event publication config get request."""
-
-    api_version: str
-    context: str
-    method: str
-    data: EventPublicationConfig
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare response data."""
-        data: GetEventPublicationConfigResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=EventPublicationConfig.from_dict(
-                data["data"]["eventPublicationConfig"]
-            ),
-        )
-
-
-@dataclass
-class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigResponse]):
-    """Request object for getting MQTT event publication config."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/event.cgi"
-    content_type = "application/json"
-    response_type = GetEventPublicationConfigResponse
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getEventPublicationConfig",
-            }
-        )
-
-
-@dataclass
-class ConfigureEventPublicationRequest(ApiRequest[Never]):
-    """Request object for configuring event publication over MQTT."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/event.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    config: EventPublicationConfig
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "configureEventPublication",
-                "params": self.config.to_dict(),
-            }
-        )
-
-
-@dataclass
 class Message:
     """Message description."""
 
@@ -736,6 +487,24 @@ class ClientStatus:
 
 
 @dataclass
+class ClientConfigStatus:
+    """GetClientStatus response."""
+
+    config: ClientConfig
+    """The Config of the MQTT client."""
+    status: ClientStatus
+    """The Status of the MQTT client."""
+
+    @classmethod
+    def from_dict(cls, data: ClientStatusDataT) -> Self:
+        """Create client config status object from dict."""
+        return cls(
+            config=ClientConfig.from_dict(data["config"]),
+            status=ClientStatus.from_dict(data["status"]),
+        )
+
+
+@dataclass
 class EventFilter:
     """Event filter."""
 
@@ -770,3 +539,237 @@ class EventFilter:
     def to_list(cls, data: list[EventFilter]) -> list[EventFilterT]:
         """Create json list from object."""
         return [item.to_dict() for item in data]
+
+
+@dataclass
+class EventPublicationConfig:
+    """Event publication config."""
+
+    topic_prefix: str | None = None
+    custom_topic_prefix: str | None = None
+    append_event_topic: bool | None = None
+    include_topic_namespaces: bool | None = None
+    include_serial_number_in_payload: bool | None = None
+    event_filter_list: list[EventFilter] | None = None
+
+    @classmethod
+    def from_dict(cls, data: EventPublicationConfigT) -> Self:
+        """Create client config status object from dict."""
+        return cls(
+            topic_prefix=data["topicPrefix"],
+            custom_topic_prefix=data["customTopicPrefix"],
+            append_event_topic=data["appendEventTopic"],
+            include_topic_namespaces=data["includeTopicNamespaces"],
+            include_serial_number_in_payload=data["includeSerialNumberInPayload"],
+            event_filter_list=EventFilter.from_list(data["eventFilterList"]),
+        )
+
+    def to_dict(self) -> EventPublicationConfigT:
+        """Create json dict from object."""
+        data: EventPublicationConfigT = {}
+        if self.topic_prefix is not None:
+            data["topicPrefix"] = self.topic_prefix
+        if self.custom_topic_prefix is not None:
+            data["customTopicPrefix"] = self.custom_topic_prefix
+        if self.append_event_topic is not None:
+            data["appendEventTopic"] = self.append_event_topic
+        if self.include_topic_namespaces is not None:
+            data["includeTopicNamespaces"] = self.include_topic_namespaces
+        if self.include_serial_number_in_payload is not None:
+            data["includeSerialNumberInPayload"] = self.include_serial_number_in_payload
+        if self.event_filter_list is not None:
+            data["eventFilterList"] = EventFilter.to_list(self.event_filter_list)
+        return data
+
+
+
+@dataclass
+class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
+    """Response object for get client status request."""
+
+    api_version: str
+    context: str
+    method: str
+    data: ClientConfigStatus
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare response data."""
+        data: GetClientStatusResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=ClientConfigStatus.from_dict(data["data"]),
+        )
+
+
+
+@dataclass
+class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
+    """Response object for event publication config get request."""
+
+    api_version: str
+    context: str
+    method: str
+    data: EventPublicationConfig
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare response data."""
+        data: GetEventPublicationConfigResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=EventPublicationConfig.from_dict(
+                data["data"]["eventPublicationConfig"]
+            ),
+        )
+
+
+
+@dataclass
+class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
+    """Request object for configuring MQTT client."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    client_config: ClientConfig
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "configureClient",
+                "params": self.client_config.to_dict(),
+            }
+        )
+
+
+@dataclass
+class ActivateClientRequest(ApiRequest[Never]):
+    """Request object for activating MQTT client."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "activateClient",
+            }
+        )
+
+
+@dataclass
+class DeactivateClientRequest(ActivateClientRequest):
+    """Request object for deactivating MQTT client."""
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "deactivateClient",
+            }
+        )
+
+
+@dataclass
+class GetClientStatusRequest(ApiRequest):
+    """Request object for getting MQTT client status."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    response_type = GetClientStatusResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getClientStatus",
+            }
+        )
+
+
+@dataclass
+class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigResponse]):
+    """Request object for getting MQTT event publication config."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/event.cgi"
+    content_type = "application/json"
+    response_type = GetEventPublicationConfigResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getEventPublicationConfig",
+            }
+        )
+
+
+@dataclass
+class ConfigureEventPublicationRequest(ApiRequest[Never]):
+    """Request object for configuring event publication over MQTT."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/event.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    config: EventPublicationConfig
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "configureEventPublication",
+                "params": self.config.to_dict(),
+            }
+        )

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -195,6 +195,255 @@ class ServerProtocol(enum.StrEnum):
 
 
 @dataclass
+class ClientConfigStatus:
+    """GetClientStatus response."""
+
+    config: ClientConfig
+    """The Config of the MQTT client."""
+    status: ClientStatus
+    """The Status of the MQTT client."""
+
+    @classmethod
+    def from_dict(cls, data: ClientStatusDataT) -> Self:
+        """Create client config status object from dict."""
+        return cls(
+            config=ClientConfig.from_dict(data["config"]),
+            status=ClientStatus.from_dict(data["status"]),
+        )
+
+
+@dataclass
+class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
+    """Response object for get client status request."""
+
+    api_version: str
+    context: str
+    method: str
+    data: ClientConfigStatus
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare response data."""
+        data: GetClientStatusResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=ClientConfigStatus.from_dict(data["data"]),
+        )
+
+
+@dataclass
+class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
+    """Request object for configuring MQTT client."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    client_config: ClientConfig
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "configureClient",
+                "params": self.client_config.to_dict(),
+            }
+        )
+
+
+@dataclass
+class ActivateClientRequest(ApiRequest[Never]):
+    """Request object for activating MQTT client."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "activateClient",
+            }
+        )
+
+
+@dataclass
+class DeactivateClientRequest(ActivateClientRequest):
+    """Request object for deactivating MQTT client."""
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "deactivateClient",
+            }
+        )
+
+
+@dataclass
+class GetClientStatusRequest(ApiRequest):
+    """Request object for getting MQTT client status."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/client.cgi"
+    content_type = "application/json"
+    response_type = GetClientStatusResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getClientStatus",
+            }
+        )
+
+
+@dataclass
+class EventPublicationConfig:
+    """Event publication config."""
+
+    topic_prefix: str | None = None
+    custom_topic_prefix: str | None = None
+    append_event_topic: bool | None = None
+    include_topic_namespaces: bool | None = None
+    include_serial_number_in_payload: bool | None = None
+    event_filter_list: list[EventFilter] | None = None
+
+    @classmethod
+    def from_dict(cls, data: EventPublicationConfigT) -> Self:
+        """Create client config status object from dict."""
+        return cls(
+            topic_prefix=data["topicPrefix"],
+            custom_topic_prefix=data["customTopicPrefix"],
+            append_event_topic=data["appendEventTopic"],
+            include_topic_namespaces=data["includeTopicNamespaces"],
+            include_serial_number_in_payload=data["includeSerialNumberInPayload"],
+            event_filter_list=EventFilter.from_list(data["eventFilterList"]),
+        )
+
+    def to_dict(self) -> EventPublicationConfigT:
+        """Create json dict from object."""
+        data: EventPublicationConfigT = {}
+        if self.topic_prefix is not None:
+            data["topicPrefix"] = self.topic_prefix
+        if self.custom_topic_prefix is not None:
+            data["customTopicPrefix"] = self.custom_topic_prefix
+        if self.append_event_topic is not None:
+            data["appendEventTopic"] = self.append_event_topic
+        if self.include_topic_namespaces is not None:
+            data["includeTopicNamespaces"] = self.include_topic_namespaces
+        if self.include_serial_number_in_payload is not None:
+            data["includeSerialNumberInPayload"] = self.include_serial_number_in_payload
+        if self.event_filter_list is not None:
+            data["eventFilterList"] = EventFilter.to_list(self.event_filter_list)
+        return data
+
+
+@dataclass
+class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
+    """Response object for event publication config get request."""
+
+    api_version: str
+    context: str
+    method: str
+    data: EventPublicationConfig
+    # error: ErrorDataT | None = None
+
+    @classmethod
+    def decode(cls, bytes_data: bytes) -> Self:
+        """Prepare response data."""
+        data: GetEventPublicationConfigResponseT = orjson.loads(bytes_data)
+        return cls(
+            api_version=data["apiVersion"],
+            context=data["context"],
+            method=data["method"],
+            data=EventPublicationConfig.from_dict(
+                data["data"]["eventPublicationConfig"]
+            ),
+        )
+
+
+@dataclass
+class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigResponse]):
+    """Request object for getting MQTT event publication config."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/event.cgi"
+    content_type = "application/json"
+    response_type = GetEventPublicationConfigResponse
+    error_codes = general_error_codes
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "getEventPublicationConfig",
+            }
+        )
+
+
+@dataclass
+class ConfigureEventPublicationRequest(ApiRequest[Never]):
+    """Request object for configuring event publication over MQTT."""
+
+    method = "post"
+    path = "/axis-cgi/mqtt/event.cgi"
+    content_type = "application/json"
+    error_codes = general_error_codes
+
+    config: EventPublicationConfig
+
+    api_version: str = API_VERSION
+    context: str = CONTEXT
+
+    @property
+    def content(self) -> bytes:
+        """Initialize request data."""
+        return orjson.dumps(
+            {
+                "apiVersion": self.api_version,
+                "context": self.context,
+                "method": "configureEventPublication",
+                "params": self.config.to_dict(),
+            }
+        )
+
+
+@dataclass
 class Message:
     """Message description."""
 
@@ -487,24 +736,6 @@ class ClientStatus:
 
 
 @dataclass
-class ClientConfigStatus:
-    """GetClientStatus response."""
-
-    config: ClientConfig
-    """The Config of the MQTT client."""
-    status: ClientStatus
-    """The Status of the MQTT client."""
-
-    @classmethod
-    def from_dict(cls, data: ClientStatusDataT) -> Self:
-        """Create client config status object from dict."""
-        return cls(
-            config=ClientConfig.from_dict(data["config"]),
-            status=ClientStatus.from_dict(data["status"]),
-        )
-
-
-@dataclass
 class EventFilter:
     """Event filter."""
 
@@ -539,234 +770,3 @@ class EventFilter:
     def to_list(cls, data: list[EventFilter]) -> list[EventFilterT]:
         """Create json list from object."""
         return [item.to_dict() for item in data]
-
-
-@dataclass
-class EventPublicationConfig:
-    """Event publication config."""
-
-    topic_prefix: str | None = None
-    custom_topic_prefix: str | None = None
-    append_event_topic: bool | None = None
-    include_topic_namespaces: bool | None = None
-    include_serial_number_in_payload: bool | None = None
-    event_filter_list: list[EventFilter] | None = None
-
-    @classmethod
-    def from_dict(cls, data: EventPublicationConfigT) -> Self:
-        """Create client config status object from dict."""
-        return cls(
-            topic_prefix=data["topicPrefix"],
-            custom_topic_prefix=data["customTopicPrefix"],
-            append_event_topic=data["appendEventTopic"],
-            include_topic_namespaces=data["includeTopicNamespaces"],
-            include_serial_number_in_payload=data["includeSerialNumberInPayload"],
-            event_filter_list=EventFilter.from_list(data["eventFilterList"]),
-        )
-
-    def to_dict(self) -> EventPublicationConfigT:
-        """Create json dict from object."""
-        data: EventPublicationConfigT = {}
-        if self.topic_prefix is not None:
-            data["topicPrefix"] = self.topic_prefix
-        if self.custom_topic_prefix is not None:
-            data["customTopicPrefix"] = self.custom_topic_prefix
-        if self.append_event_topic is not None:
-            data["appendEventTopic"] = self.append_event_topic
-        if self.include_topic_namespaces is not None:
-            data["includeTopicNamespaces"] = self.include_topic_namespaces
-        if self.include_serial_number_in_payload is not None:
-            data["includeSerialNumberInPayload"] = self.include_serial_number_in_payload
-        if self.event_filter_list is not None:
-            data["eventFilterList"] = EventFilter.to_list(self.event_filter_list)
-        return data
-
-
-@dataclass
-class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
-    """Request object for configuring MQTT client."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    client_config: ClientConfig
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "configureClient",
-                "params": self.client_config.to_dict(),
-            }
-        )
-
-
-@dataclass
-class ActivateClientRequest(ApiRequest[Never]):
-    """Request object for activating MQTT client."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "activateClient",
-            }
-        )
-
-
-@dataclass
-class DeactivateClientRequest(ActivateClientRequest):
-    """Request object for deactivating MQTT client."""
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "deactivateClient",
-            }
-        )
-
-
-@dataclass
-class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
-    """Response object for get client status request."""
-
-    api_version: str
-    context: str
-    method: str
-    data: ClientConfigStatus
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare response data."""
-        data: GetClientStatusResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=ClientConfigStatus.from_dict(data["data"]),
-        )
-
-
-@dataclass
-class GetClientStatusRequest(ApiRequest):
-    """Request object for getting MQTT client status."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/client.cgi"
-    content_type = "application/json"
-    response_type = GetClientStatusResponse
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getClientStatus",
-            }
-        )
-
-
-@dataclass
-class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
-    """Response object for event publication config get request."""
-
-    api_version: str
-    context: str
-    method: str
-    data: EventPublicationConfig
-    # error: ErrorDataT | None = None
-
-    @classmethod
-    def decode(cls, bytes_data: bytes) -> Self:
-        """Prepare response data."""
-        data: GetEventPublicationConfigResponseT = orjson.loads(bytes_data)
-        return cls(
-            api_version=data["apiVersion"],
-            context=data["context"],
-            method=data["method"],
-            data=EventPublicationConfig.from_dict(
-                data["data"]["eventPublicationConfig"]
-            ),
-        )
-
-
-@dataclass
-class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigResponse]):
-    """Request object for getting MQTT event publication config."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/event.cgi"
-    content_type = "application/json"
-    response_type = GetEventPublicationConfigResponse
-    error_codes = general_error_codes
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "getEventPublicationConfig",
-            }
-        )
-
-
-@dataclass
-class ConfigureEventPublicationRequest(ApiRequest[Never]):
-    """Request object for configuring event publication over MQTT."""
-
-    method = "post"
-    path = "/axis-cgi/mqtt/event.cgi"
-    content_type = "application/json"
-    error_codes = general_error_codes
-
-    config: EventPublicationConfig
-
-    api_version: str = API_VERSION
-    context: str = CONTEXT
-
-    @property
-    def content(self) -> bytes:
-        """Initialize request data."""
-        return orjson.dumps(
-            {
-                "apiVersion": self.api_version,
-                "context": self.context,
-                "method": "configureEventPublication",
-                "params": self.config.to_dict(),
-            }
-        )

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """MQTT Client api."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Never, Any, Literal, NotRequired, Self, TypedDict
+from typing import Any, Literal, Never, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -582,7 +582,6 @@ class EventPublicationConfig:
         return data
 
 
-
 @dataclass
 class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
     """Response object for get client status request."""
@@ -603,7 +602,6 @@ class GetClientStatusResponse(ApiResponse[ClientConfigStatus]):
             method=data["method"],
             data=ClientConfigStatus.from_dict(data["data"]),
         )
-
 
 
 @dataclass
@@ -628,7 +626,6 @@ class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
                 data["data"]["eventPublicationConfig"]
             ),
         )
-
 
 
 @dataclass
@@ -699,7 +696,7 @@ class DeactivateClientRequest(ActivateClientRequest):
 
 
 @dataclass
-class GetClientStatusRequest(ApiRequest):
+class GetClientStatusRequest(ApiRequest[GetClientStatusResponse]):
     """Request object for getting MQTT client status."""
 
     method = "post"

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -629,7 +629,7 @@ class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
 
 
 @dataclass
-class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
+class ConfigureClientRequest(ApiRequest[Never]):
     """Request object for configuring MQTT client."""
 
     method = "post"

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, NotRequired, Self, TypedDict
 
 import orjson
 
-from .api import CONTEXT, ApiRequest, ApiResponse
+from .api import CONTEXT, ApiRequest, ApiResponse, BytesResponse
 
 API_VERSION = "1.0"
 
@@ -629,12 +629,13 @@ class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
 
 
 @dataclass
-class ConfigureClientRequest(ApiRequest[bytes]):
+class ConfigureClientRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for configuring MQTT client."""
 
     method = "post"
     path = "/axis-cgi/mqtt/client.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     client_config: ClientConfig
@@ -656,12 +657,13 @@ class ConfigureClientRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class ActivateClientRequest(ApiRequest[bytes]):
+class ActivateClientRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for activating MQTT client."""
 
     method = "post"
     path = "/axis-cgi/mqtt/client.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     api_version: str = API_VERSION
@@ -746,12 +748,13 @@ class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigRespo
 
 
 @dataclass
-class ConfigureEventPublicationRequest(ApiRequest[bytes]):
+class ConfigureEventPublicationRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for configuring event publication over MQTT."""
 
     method = "post"
     path = "/axis-cgi/mqtt/event.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = general_error_codes
 
     config: EventPublicationConfig

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 """MQTT Client api."""
 
 from dataclasses import dataclass
 import enum
-from typing import Any, Literal, NotRequired, Self, TypedDict
+from typing import Never, Any, Literal, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -581,7 +583,7 @@ class EventPublicationConfig:
 
 
 @dataclass
-class ConfigureClientRequest(ApiRequest):
+class ConfigureClientRequest(ApiRequest[GetClientStatusResponse]):
     """Request object for configuring MQTT client."""
 
     method = "post"
@@ -608,7 +610,7 @@ class ConfigureClientRequest(ApiRequest):
 
 
 @dataclass
-class ActivateClientRequest(ApiRequest):
+class ActivateClientRequest(ApiRequest[Never]):
     """Request object for activating MQTT client."""
 
     method = "post"
@@ -719,7 +721,7 @@ class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
 
 
 @dataclass
-class GetEventPublicationConfigRequest(ApiRequest):
+class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigResponse]):
     """Request object for getting MQTT event publication config."""
 
     method = "post"
@@ -744,7 +746,7 @@ class GetEventPublicationConfigRequest(ApiRequest):
 
 
 @dataclass
-class ConfigureEventPublicationRequest(ApiRequest):
+class ConfigureEventPublicationRequest(ApiRequest[Never]):
     """Request object for configuring event publication over MQTT."""
 
     method = "post"

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Any, Literal, Never, NotRequired, Self, TypedDict
+from typing import Any, Literal, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -629,7 +629,7 @@ class GetEventPublicationConfigResponse(ApiResponse[EventPublicationConfig]):
 
 
 @dataclass
-class ConfigureClientRequest(ApiRequest[Never]):
+class ConfigureClientRequest(ApiRequest[bytes]):
     """Request object for configuring MQTT client."""
 
     method = "post"
@@ -656,7 +656,7 @@ class ConfigureClientRequest(ApiRequest[Never]):
 
 
 @dataclass
-class ActivateClientRequest(ApiRequest[Never]):
+class ActivateClientRequest(ApiRequest[bytes]):
     """Request object for activating MQTT client."""
 
     method = "post"
@@ -746,7 +746,7 @@ class GetEventPublicationConfigRequest(ApiRequest[GetEventPublicationConfigRespo
 
 
 @dataclass
-class ConfigureEventPublicationRequest(ApiRequest[Never]):
+class ConfigureEventPublicationRequest(ApiRequest[bytes]):
     """Request object for configuring event publication over MQTT."""
 
     method = "post"

--- a/axis/models/mqtt.py
+++ b/axis/models/mqtt.py
@@ -1,7 +1,5 @@
 """MQTT Client api."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 from typing import Any, Literal, NotRequired, Self, TypedDict

--- a/axis/models/parameters/param_cgi.py
+++ b/axis/models/parameters/param_cgi.py
@@ -119,7 +119,7 @@ class ParamResponse(ApiResponse[dict[str, Any]]):
 
 
 @dataclass
-class ParamRequest(ApiRequest):
+class ParamRequest(ApiRequest[ParamResponse]):
     """Request object for listing parameters."""
 
     method = "post"

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -9,7 +9,7 @@ from typing import NotRequired, Self, TypedDict
 
 import orjson
 
-from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
+from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse, BytesResponse
 
 API_VERSION = "1.0"
 
@@ -218,12 +218,13 @@ class GetSensitivityRequest(ApiRequest[GetSensitivityResponse]):
 
 
 @dataclass
-class SetSensitivityRequest(ApiRequest[bytes]):
+class SetSensitivityRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for setting PIR sensor sensitivity."""
 
     method = "post"
     path = "/axis-cgi/pirsensor.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = sensor_specific_error_codes
 
     id: int

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -271,7 +271,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -5,7 +5,7 @@ the sensitivity of the PIR (passive infrared) sensors on your Axis device.
 """
 
 from dataclasses import dataclass
-from typing import Never, NotRequired, Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 import orjson
 
@@ -218,7 +218,7 @@ class GetSensitivityRequest(ApiRequest[GetSensitivityResponse]):
 
 
 @dataclass
-class SetSensitivityRequest(ApiRequest[Never]):
+class SetSensitivityRequest(ApiRequest[bytes]):
     """Request object for setting PIR sensor sensitivity."""
 
     method = "post"

--- a/axis/models/pir_sensor_configuration.py
+++ b/axis/models/pir_sensor_configuration.py
@@ -5,7 +5,7 @@ the sensitivity of the PIR (passive infrared) sensors on your Axis device.
 """
 
 from dataclasses import dataclass
-from typing import NotRequired, Self, TypedDict
+from typing import Never, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -141,7 +141,7 @@ class ListSensorsResponse(ApiResponse[dict[str, PirSensorConfiguration]]):
 
 
 @dataclass
-class ListSensorsRequest(ApiRequest):
+class ListSensorsRequest(ApiRequest[ListSensorsResponse]):
     """Request object for listing PIR sensors."""
 
     method = "post"
@@ -188,7 +188,7 @@ class GetSensitivityResponse(ApiResponse[float | None]):
 
 
 @dataclass
-class GetSensitivityRequest(ApiRequest):
+class GetSensitivityRequest(ApiRequest[GetSensitivityResponse]):
     """Request object for getting PIR sensor sensitivity."""
 
     method = "post"
@@ -218,7 +218,7 @@ class GetSensitivityRequest(ApiRequest):
 
 
 @dataclass
-class SetSensitivityRequest(ApiRequest):
+class SetSensitivityRequest(ApiRequest[Never]):
     """Request object for setting PIR sensor sensitivity."""
 
     method = "post"

--- a/axis/models/port_cgi.py
+++ b/axis/models/port_cgi.py
@@ -7,13 +7,12 @@ Virtual input API.
 """
 
 from dataclasses import dataclass
-from typing import Never
 
 from .api import ApiRequest
 
 
 @dataclass
-class PortActionRequest(ApiRequest[Never]):
+class PortActionRequest(ApiRequest[bytes]):
     r"""Request object for activate or deactivate an output.
 
     Use the <wait> option to activate/deactivate the port for a

--- a/axis/models/port_cgi.py
+++ b/axis/models/port_cgi.py
@@ -8,11 +8,11 @@ Virtual input API.
 
 from dataclasses import dataclass
 
-from .api import ApiRequest
+from .api import ApiRequest, ApiResponse, BytesResponse
 
 
 @dataclass
-class PortActionRequest(ApiRequest[bytes]):
+class PortActionRequest(ApiRequest[ApiResponse[bytes]]):
     r"""Request object for activate or deactivate an output.
 
     Use the <wait> option to activate/deactivate the port for a
@@ -33,6 +33,7 @@ class PortActionRequest(ApiRequest[bytes]):
     method = "get"
     path = "/axis-cgi/io/port.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     port: str
     action: str

--- a/axis/models/port_cgi.py
+++ b/axis/models/port_cgi.py
@@ -7,12 +7,13 @@ Virtual input API.
 """
 
 from dataclasses import dataclass
+from typing import Never
 
 from .api import ApiRequest
 
 
 @dataclass
-class PortActionRequest(ApiRequest):
+class PortActionRequest(ApiRequest[Never]):
     r"""Request object for activate or deactivate an output.
 
     Use the <wait> option to activate/deactivate the port for a

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -9,7 +9,7 @@ from typing import Literal, NotRequired, Self, TypedDict
 
 import orjson
 
-from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse
+from .api import CONTEXT, ApiItem, ApiRequest, ApiResponse, BytesResponse
 
 API_VERSION = "1.0"
 
@@ -224,12 +224,13 @@ class GetPortsRequest(ApiRequest[GetPortsResponse]):
 
 
 @dataclass
-class SetPortsRequest(ApiRequest[bytes]):
+class SetPortsRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for configuring ports."""
 
     method = "post"
     path = "/axis-cgi/io/portmanagement.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = error_codes
 
     port_config: list[PortConfiguration] | PortConfiguration
@@ -254,12 +255,13 @@ class SetPortsRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class SetStateSequenceRequest(ApiRequest[bytes]):
+class SetStateSequenceRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for configuring port sequence."""
 
     method = "post"
     path = "/axis-cgi/io/portmanagement.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
     error_codes = error_codes
 
     port: str

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -5,7 +5,7 @@ information about the ports and apply product dependent configurations
 """
 
 from dataclasses import dataclass
-from typing import Never, Literal, NotRequired, Self, TypedDict
+from typing import Literal, Never, NotRequired, Self, TypedDict
 
 import orjson
 

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -5,7 +5,7 @@ information about the ports and apply product dependent configurations
 """
 
 from dataclasses import dataclass
-from typing import Literal, Never, NotRequired, Self, TypedDict
+from typing import Literal, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -224,7 +224,7 @@ class GetPortsRequest(ApiRequest[GetPortsResponse]):
 
 
 @dataclass
-class SetPortsRequest(ApiRequest[Never]):
+class SetPortsRequest(ApiRequest[bytes]):
     """Request object for configuring ports."""
 
     method = "post"
@@ -254,7 +254,7 @@ class SetPortsRequest(ApiRequest[Never]):
 
 
 @dataclass
-class SetStateSequenceRequest(ApiRequest[Never]):
+class SetStateSequenceRequest(ApiRequest[bytes]):
     """Request object for configuring port sequence."""
 
     method = "post"

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -254,7 +254,7 @@ class SetPortsRequest(ApiRequest[Never]):
 
 
 @dataclass
-class SetStateSequenceRequest(ApiRequest):
+class SetStateSequenceRequest(ApiRequest[Never]):
     """Request object for configuring port sequence."""
 
     method = "post"
@@ -305,7 +305,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/port_management.py
+++ b/axis/models/port_management.py
@@ -5,7 +5,7 @@ information about the ports and apply product dependent configurations
 """
 
 from dataclasses import dataclass
-from typing import Literal, NotRequired, Self, TypedDict
+from typing import Never, Literal, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -199,7 +199,7 @@ class GetPortsResponse(ApiResponse[dict[str, Port]]):
 
 
 @dataclass
-class GetPortsRequest(ApiRequest):
+class GetPortsRequest(ApiRequest[GetPortsResponse]):
     """Request object for listing ports."""
 
     method = "post"
@@ -224,7 +224,7 @@ class GetPortsRequest(ApiRequest):
 
 
 @dataclass
-class SetPortsRequest(ApiRequest):
+class SetPortsRequest(ApiRequest[Never]):
     """Request object for configuring ports."""
 
     method = "post"

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -5,6 +5,9 @@ The PTZ control is device-dependent. For information about supported parameters
 and actual parameter values, check the specification of the Axis PTZ driver used.
 """
 
+from __future__ import annotations
+
+
 from dataclasses import dataclass
 import enum
 
@@ -92,7 +95,7 @@ class PtzQuery(enum.StrEnum):
 
 
 @dataclass
-class PtzControlRequest(ApiRequest):
+class PtzControlRequest(ApiRequest[Never]):
     """Control pan, tilt and zoom behavior of a PTZ unit."""
 
     method = "post"
@@ -337,7 +340,7 @@ class PtzControlRequest(ApiRequest):
 
 
 @dataclass
-class PtzCommandRequest(ApiRequest):
+class PtzCommandRequest(ApiRequest[Never]):
     """Retrieve available PTZ commands."""
 
     method = "post"
@@ -351,7 +354,7 @@ class PtzCommandRequest(ApiRequest):
 
 
 @dataclass
-class DeviceDriverRequest(ApiRequest):
+class DeviceDriverRequest(ApiRequest[Never]):
     """Retrieve name of the device driver."""
 
     method = "post"
@@ -365,7 +368,7 @@ class DeviceDriverRequest(ApiRequest):
 
 
 @dataclass
-class QueryRequest(ApiRequest):
+class QueryRequest(ApiRequest[Never]):
     """Retrieve current status."""
 
     method = "post"

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
-from typing import Never
 
 from .api import ApiRequest
 
@@ -95,7 +94,7 @@ class PtzQuery(enum.StrEnum):
 
 
 @dataclass
-class PtzControlRequest(ApiRequest[Never]):
+class PtzControlRequest(ApiRequest[bytes]):
     """Control pan, tilt and zoom behavior of a PTZ unit."""
 
     method = "post"
@@ -340,7 +339,7 @@ class PtzControlRequest(ApiRequest[Never]):
 
 
 @dataclass
-class PtzCommandRequest(ApiRequest[Never]):
+class PtzCommandRequest(ApiRequest[bytes]):
     """Retrieve available PTZ commands."""
 
     method = "post"
@@ -354,7 +353,7 @@ class PtzCommandRequest(ApiRequest[Never]):
 
 
 @dataclass
-class DeviceDriverRequest(ApiRequest[Never]):
+class DeviceDriverRequest(ApiRequest[bytes]):
     """Retrieve name of the device driver."""
 
     method = "post"
@@ -368,7 +367,7 @@ class DeviceDriverRequest(ApiRequest[Never]):
 
 
 @dataclass
-class QueryRequest(ApiRequest[Never]):
+class QueryRequest(ApiRequest[bytes]):
     """Retrieve current status."""
 
     method = "post"

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -7,7 +7,6 @@ and actual parameter values, check the specification of the Axis PTZ driver used
 
 from __future__ import annotations
 
-
 from dataclasses import dataclass
 import enum
 from typing import Never

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -5,8 +5,6 @@ The PTZ control is device-dependent. For information about supported parameters
 and actual parameter values, check the specification of the Axis PTZ driver used.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import enum
 

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import enum
+from typing import Never
 
 from .api import ApiRequest
 

--- a/axis/models/ptz_cgi.py
+++ b/axis/models/ptz_cgi.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import enum
 
-from .api import ApiRequest
+from .api import ApiRequest, ApiResponse, BytesResponse
 
 
 class PtzMove(enum.StrEnum):
@@ -94,12 +94,13 @@ class PtzQuery(enum.StrEnum):
 
 
 @dataclass
-class PtzControlRequest(ApiRequest[bytes]):
+class PtzControlRequest(ApiRequest[ApiResponse[bytes]]):
     """Control pan, tilt and zoom behavior of a PTZ unit."""
 
     method = "post"
     path = "/axis-cgi/com/ptz.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     camera: int | None = None
     """Selects the video channel.
@@ -339,12 +340,13 @@ class PtzControlRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class PtzCommandRequest(ApiRequest[bytes]):
+class PtzCommandRequest(ApiRequest[ApiResponse[bytes]]):
     """Retrieve available PTZ commands."""
 
     method = "post"
     path = "/axis-cgi/com/ptz.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     @property
     def data(self) -> dict[str, str]:
@@ -353,12 +355,13 @@ class PtzCommandRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class DeviceDriverRequest(ApiRequest[bytes]):
+class DeviceDriverRequest(ApiRequest[ApiResponse[bytes]]):
     """Retrieve name of the device driver."""
 
     method = "post"
     path = "/axis-cgi/com/ptz.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     @property
     def data(self) -> dict[str, str]:
@@ -367,12 +370,13 @@ class DeviceDriverRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class QueryRequest(ApiRequest[bytes]):
+class QueryRequest(ApiRequest[ApiResponse[bytes]]):
     """Retrieve current status."""
 
     method = "post"
     path = "/axis-cgi/com/ptz.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     query: PtzQuery
 

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import enum
-from typing import Self, TypedDict
+from typing import Never, Self, TypedDict
 
 from .api import ApiItem, ApiRequest, ApiResponse
 
@@ -105,7 +105,7 @@ class GetUsersResponse(ApiResponse[dict[str, User]]):
 
 
 @dataclass
-class GetUsersRequest(ApiRequest):
+class GetUsersRequest(ApiRequest[GetUsersResponse]):
     """Request object for listing users."""
 
     method = "post"
@@ -180,7 +180,7 @@ class ModifyUserRequest(ApiRequest):
 
 
 @dataclass
-class DeleteUserRequest(ApiRequest):
+class DeleteUserRequest(ApiRequest[Never]):
     """Request object for deleting a user."""
 
     method = "post"

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -120,7 +120,7 @@ class GetUsersRequest(ApiRequest[GetUsersResponse]):
 
 
 @dataclass
-class CreateUserRequest(ApiRequest):
+class CreateUserRequest(ApiRequest[Never]):
     """Request object for creating a user."""
 
     method = "post"
@@ -150,7 +150,7 @@ class CreateUserRequest(ApiRequest):
 
 
 @dataclass
-class ModifyUserRequest(ApiRequest):
+class ModifyUserRequest(ApiRequest[Never]):
     """Request object for modifying a user."""
 
     method = "post"

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import enum
-from typing import Never, Self, TypedDict
+from typing import Self, TypedDict
 
 from .api import ApiItem, ApiRequest, ApiResponse
 
@@ -120,7 +120,7 @@ class GetUsersRequest(ApiRequest[GetUsersResponse]):
 
 
 @dataclass
-class CreateUserRequest(ApiRequest[Never]):
+class CreateUserRequest(ApiRequest[bytes]):
     """Request object for creating a user."""
 
     method = "post"
@@ -150,7 +150,7 @@ class CreateUserRequest(ApiRequest[Never]):
 
 
 @dataclass
-class ModifyUserRequest(ApiRequest[Never]):
+class ModifyUserRequest(ApiRequest[bytes]):
     """Request object for modifying a user."""
 
     method = "post"
@@ -180,7 +180,7 @@ class ModifyUserRequest(ApiRequest[Never]):
 
 
 @dataclass
-class DeleteUserRequest(ApiRequest[Never]):
+class DeleteUserRequest(ApiRequest[bytes]):
     """Request object for deleting a user."""
 
     method = "post"

--- a/axis/models/pwdgrp_cgi.py
+++ b/axis/models/pwdgrp_cgi.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import enum
 from typing import Self, TypedDict
 
-from .api import ApiItem, ApiRequest, ApiResponse
+from .api import ApiItem, ApiRequest, ApiResponse, BytesResponse
 
 
 class SecondaryGroup(enum.StrEnum):
@@ -120,12 +120,13 @@ class GetUsersRequest(ApiRequest[GetUsersResponse]):
 
 
 @dataclass
-class CreateUserRequest(ApiRequest[bytes]):
+class CreateUserRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for creating a user."""
 
     method = "post"
     path = "/axis-cgi/pwdgrp.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     user: str
     pwd: str
@@ -150,12 +151,13 @@ class CreateUserRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class ModifyUserRequest(ApiRequest[bytes]):
+class ModifyUserRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for modifying a user."""
 
     method = "post"
     path = "/axis-cgi/pwdgrp.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     user: str
     pwd: str | None = None
@@ -180,12 +182,13 @@ class ModifyUserRequest(ApiRequest[bytes]):
 
 
 @dataclass
-class DeleteUserRequest(ApiRequest[bytes]):
+class DeleteUserRequest(ApiRequest[ApiResponse[bytes]]):
     """Request object for deleting a user."""
 
     method = "post"
     path = "/axis-cgi/pwdgrp.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
     user: str
 

--- a/axis/models/stream_profile.py
+++ b/axis/models/stream_profile.py
@@ -117,7 +117,7 @@ class ListStreamProfilesResponse(ApiResponse[dict[str, StreamProfile]]):
 
 
 @dataclass
-class ListStreamProfilesRequest(ApiRequest):
+class ListStreamProfilesRequest(ApiRequest[ListStreamProfilesResponse]):
     """Request object for listing stream profiles descriptions."""
 
     method = "post"
@@ -168,7 +168,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/user_group.py
+++ b/axis/models/user_group.py
@@ -37,7 +37,7 @@ class GetUserGroupResponse(ApiResponse[dict[str, User]]):
 
 
 @dataclass
-class GetUserGroupRequest(ApiRequest):
+class GetUserGroupRequest(ApiRequest[GetUserGroupResponse]):
     """Request object for listing users."""
 
     method = "get"

--- a/axis/models/view_area.py
+++ b/axis/models/view_area.py
@@ -1,7 +1,7 @@
 """View area API data model."""
 
 from dataclasses import dataclass
-from typing import NotRequired, Self, TypedDict
+from typing import Never, NotRequired, Self, TypedDict
 
 import orjson
 
@@ -190,7 +190,7 @@ class ListViewAreasResponse(ApiResponse[dict[str, ViewArea]]):
 
 
 @dataclass
-class ListViewAreasRequest(ApiRequest):
+class ListViewAreasRequest(ApiRequest[ListViewAreasResponse]):
     """Request object for listing view areas."""
 
     method = "post"
@@ -215,7 +215,7 @@ class ListViewAreasRequest(ApiRequest):
 
 
 @dataclass
-class SetGeometryRequest(ApiRequest):
+class SetGeometryRequest(ApiRequest[Never]):
     """Request object for setting geometry of a view area."""
 
     method = "post"
@@ -254,7 +254,7 @@ class SetGeometryRequest(ApiRequest):
 
 
 @dataclass
-class ResetGeometryRequest(ApiRequest):
+class ResetGeometryRequest(ApiRequest[Never]):
     """Request object for resetting geometry of a view area."""
 
     method = "post"
@@ -304,7 +304,7 @@ class GetSupportedVersionsResponse(ApiResponse[list[str]]):
 
 
 @dataclass
-class GetSupportedVersionsRequest(ApiRequest):
+class GetSupportedVersionsRequest(ApiRequest[GetSupportedVersionsResponse]):
     """Request object for listing supported API versions."""
 
     method = "post"

--- a/axis/models/view_area.py
+++ b/axis/models/view_area.py
@@ -1,7 +1,7 @@
 """View area API data model."""
 
 from dataclasses import dataclass
-from typing import Never, NotRequired, Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 import orjson
 
@@ -215,7 +215,7 @@ class ListViewAreasRequest(ApiRequest[ListViewAreasResponse]):
 
 
 @dataclass
-class SetGeometryRequest(ApiRequest[Never]):
+class SetGeometryRequest(ApiRequest[ListViewAreasResponse]):
     """Request object for setting geometry of a view area."""
 
     method = "post"
@@ -254,7 +254,7 @@ class SetGeometryRequest(ApiRequest[Never]):
 
 
 @dataclass
-class ResetGeometryRequest(ApiRequest[Never]):
+class ResetGeometryRequest(ApiRequest[ListViewAreasResponse]):
     """Request object for resetting geometry of a view area."""
 
     method = "post"

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import axis.models
-from axis.models.api import ApiRequest
+from axis.models.api import ApiRequest, BytesResponse
 
 from tests.conftest import (
     MOCK_API_REQUEST_DIRECT_CONTENT_TYPES,
@@ -26,54 +26,63 @@ class _JsonApiRequest(ApiRequest):
     method = "POST"
     path = "/axis-cgi/mock/json.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
 
 
 class _PlainTextApiRequest(ApiRequest):
     method = "GET"
     path = "/axis-cgi/mock/plain.cgi"
     content_type = "text/plain"
+    response_type = BytesResponse
 
 
 class _XmlApiRequest(ApiRequest):
     method = "POST"
     path = "/axis-cgi/mock/xml.cgi"
     content_type = "text/xml"
+    response_type = BytesResponse
 
 
 class _UnsupportedTypeApiRequest(ApiRequest):
     method = "POST"
     path = "/axis-cgi/mock/unsupported-type.cgi"
     content_type = "application/octet-stream"
+    response_type = BytesResponse
 
 
 class _UnsupportedMethodApiRequest(ApiRequest):
     method = "DELETE"
     path = "/axis-cgi/mock/unsupported-method.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
 
 
 class _LowerCaseMethodApiRequest(ApiRequest):
     method = "post"
     path = "/axis-cgi/mock/lowercase-method.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
 
 
 class _BlankMethodApiRequest(ApiRequest):
     method = "   "
     path = "/axis-cgi/mock/blank-method.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
 
 
 class _AssertionApiRequest(ApiRequest):
     method = "POST"
     path = "/axis-cgi/mock/assertions.cgi"
     content_type = "application/json"
+    response_type = BytesResponse
 
 
 class _ExplicitResponseOnlyApiRequest(ApiRequest):
     method = "POST"
     path = "/axis-cgi/mock/explicit-only.cgi"
     content_type = "application/octet-stream"
+    response_type = BytesResponse
 
 
 def _iter_api_request_classes() -> list[type[ApiRequest]]:

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -1,7 +1,10 @@
 """Tests for request/response typed contract mappings."""
 
+from typing import Never, get_args, get_origin
+
 import pytest
 
+from axis.models.api import ApiRequest
 from axis.models.api_discovery import (
     GetAllApisResponse,
     GetSupportedVersionsRequest as ApiDiscoveryGetSupportedVersionsRequest,
@@ -206,6 +209,9 @@ from axis.models.view_area import (
 def test_request_response_type_contracts(request_cls, response_cls) -> None:
     """Verify request classes expose the intended typed response contract."""
     assert request_cls.response_type is response_cls
+    generic_base = request_cls.__orig_bases__[0]
+    assert get_origin(generic_base) is ApiRequest
+    assert get_args(generic_base) == (response_cls,)
 
 
 @pytest.mark.parametrize(
@@ -230,3 +236,6 @@ def test_request_response_type_contracts(request_cls, response_cls) -> None:
 def test_write_and_bytes_requests_have_no_response_contract(request_cls) -> None:
     """Verify non-decoded request classes keep an empty typed response contract."""
     assert request_cls.response_type is None
+    generic_base = request_cls.__orig_bases__[0]
+    assert get_origin(generic_base) is ApiRequest
+    assert get_args(generic_base) == (Never,)

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -1,10 +1,10 @@
 """Tests for request/response typed contract mappings."""
 
-from typing import Never, get_args, get_origin
+from typing import get_args, get_origin
 
 import pytest
 
-from axis.models.api import ApiRequest
+from axis.models.api import ApiRequest, BytesResponse
 from axis.models.api_discovery import (
     GetAllApisResponse,
     GetSupportedVersionsRequest as ApiDiscoveryGetSupportedVersionsRequest,
@@ -234,8 +234,8 @@ def test_request_response_type_contracts(request_cls, response_cls) -> None:
     ],
 )
 def test_write_and_bytes_requests_have_no_response_contract(request_cls) -> None:
-    """Verify non-decoded request classes keep an empty typed response contract."""
-    assert request_cls.response_type is None
+    """Verify non-decoded request classes use the raw-bytes response contract."""
+    assert request_cls.response_type is BytesResponse
     generic_base = request_cls.__orig_bases__[0]
     assert get_origin(generic_base) is ApiRequest
-    assert get_args(generic_base) == (Never,)
+    assert get_args(generic_base) == (bytes,)

--- a/tests/test_request_response_contracts.py
+++ b/tests/test_request_response_contracts.py
@@ -4,7 +4,7 @@ from typing import get_args, get_origin
 
 import pytest
 
-from axis.models.api import ApiRequest, BytesResponse
+from axis.models.api import ApiRequest, ApiResponse, BytesResponse
 from axis.models.api_discovery import (
     GetAllApisResponse,
     GetSupportedVersionsRequest as ApiDiscoveryGetSupportedVersionsRequest,
@@ -234,8 +234,8 @@ def test_request_response_type_contracts(request_cls, response_cls) -> None:
     ],
 )
 def test_write_and_bytes_requests_have_no_response_contract(request_cls) -> None:
-    """Verify non-decoded request classes use the raw-bytes response contract."""
+    """Verify write requests use wrapped raw-byte response contracts."""
     assert request_cls.response_type is BytesResponse
     generic_base = request_cls.__orig_bases__[0]
     assert get_origin(generic_base) is ApiRequest
-    assert get_args(generic_base) == (bytes,)
+    assert get_args(generic_base) == (ApiResponse[bytes],)

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -333,7 +333,7 @@ async def test_initialize_api_discovery(mock_vapix_request, vapix: Vapix):
     assert len(vapix.stream_profiles) == 1
 
 
-async def test_api_request_typed_uses_request_response_type(
+async def test_api_request_uses_request_response_type(
     mock_vapix_request, vapix: Vapix
 ):
     """Verify typed request decoding can use request-level response metadata."""
@@ -347,13 +347,13 @@ async def test_api_request_typed_uses_request_response_type(
         },
     )
 
-    response = await vapix.api_request_typed(ListViewAreasRequest(api_version="1.0"))
+    response = await vapix.api_request(ListViewAreasRequest(api_version="1.0"))
 
     assert isinstance(response, ListViewAreasResponse)
     assert response.data == {}
 
 
-async def test_api_request_typed_uses_param_request_response_type(
+async def test_api_request_uses_param_request_response_type(
     mock_vapix_request, vapix: Vapix
 ):
     """Verify typed request decoding uses ParamRequest response metadata."""
@@ -363,13 +363,13 @@ async def test_api_request_typed_uses_param_request_response_type(
         headers={"Content-Type": "text/plain; charset=iso-8859-1"},
     )
 
-    response = await vapix.api_request_typed(ParamRequest())
+    response = await vapix.api_request(ParamRequest())
 
     assert "Brand" in response.data
     assert response.data["Brand"]["Brand"] == "AXIS"
 
 
-async def test_api_request_typed_uses_applications_request_response_type(
+async def test_api_request_uses_applications_request_response_type(
     mock_vapix_request, vapix: Vapix
 ):
     """Verify typed request decoding uses ListApplicationsRequest metadata."""
@@ -379,18 +379,31 @@ async def test_api_request_typed_uses_applications_request_response_type(
         headers={"Content-Type": "text/xml"},
     )
 
-    response = await vapix.api_request_typed(ListApplicationsRequest())
+    response = await vapix.api_request(ListApplicationsRequest())
 
     assert response.data["vmd"].status == ApplicationStatus.RUNNING
 
 
-async def test_api_request_typed_requires_response_type(vapix: Vapix):
-    """Verify typed request helper errors when request has no response contract."""
+async def test_api_request_requires_response_type(vapix: Vapix):
+    """Verify api_request errors when request has no response contract."""
     with pytest.raises(ValueError, match="No response type configured"):
-        await vapix.api_request_typed(SetPortsRequest(PortConfiguration(port="0")))
+        await vapix.api_request(SetPortsRequest(PortConfiguration(port="0")))
 
 
-async def test_api_request_typed_decodes_using_request_response_type(
+async def test_api_request_bytes_returns_raw_bytes_for_request_without_response_type(
+    mock_vapix_request, vapix: Vapix
+):
+    """Verify private bytes helper returns raw bytes for requests without response metadata."""
+    mock_vapix_request(SetPortsRequest, json={})
+
+    response = await vapix._api_request_bytes(
+        SetPortsRequest(PortConfiguration(port="0"))
+    )
+
+    assert isinstance(response, bytes)
+
+
+async def test_api_request_decodes_using_request_response_type(
     mock_vapix_request, vapix: Vapix
 ):
     """Verify typed helper decodes response using the request's response_type contract."""
@@ -400,7 +413,7 @@ async def test_api_request_typed_decodes_using_request_response_type(
         headers={"Content-Type": "text/plain"},
     )
 
-    response = await vapix.api_request_typed(GetUserGroupRequest())
+    response = await vapix.api_request(GetUserGroupRequest())
 
     assert isinstance(response, GetUserGroupResponse)
     assert response.data["0"].admin

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -382,21 +382,13 @@ async def test_api_request_uses_applications_request_response_type(
     assert response.data["vmd"].status == ApplicationStatus.RUNNING
 
 
-async def test_api_request_requires_response_type(vapix: Vapix):
-    """Verify api_request errors when request has no response contract."""
-    with pytest.raises(ValueError, match="No response type configured"):
-        await vapix.api_request(SetPortsRequest(PortConfiguration(port="0")))
-
-
-async def test_api_request_bytes_returns_raw_bytes_for_request_without_response_type(
+async def test_api_request_returns_raw_bytes_for_request_without_response_type(
     mock_vapix_request, vapix: Vapix
 ):
-    """Verify private bytes helper returns raw bytes for requests without response metadata."""
+    """Verify api_request returns raw bytes for requests without response metadata."""
     mock_vapix_request(SetPortsRequest, json={})
 
-    response = await vapix._api_request_bytes(
-        SetPortsRequest(PortConfiguration(port="0"))
-    )
+    response = await vapix.api_request(SetPortsRequest(PortConfiguration(port="0")))
 
     assert isinstance(response, bytes)
 

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -333,9 +333,7 @@ async def test_initialize_api_discovery(mock_vapix_request, vapix: Vapix):
     assert len(vapix.stream_profiles) == 1
 
 
-async def test_api_request_uses_request_response_type(
-    mock_vapix_request, vapix: Vapix
-):
+async def test_api_request_uses_request_response_type(mock_vapix_request, vapix: Vapix):
     """Verify typed request decoding can use request-level response metadata."""
     mock_vapix_request(
         ListViewAreasRequest,

--- a/tests/test_vapix.py
+++ b/tests/test_vapix.py
@@ -15,6 +15,7 @@ from axis.errors import (
     Unauthorized,
 )
 from axis.interfaces.api_handler import HandlerGroup
+from axis.models.api import BytesResponse
 from axis.models.api_discovery import ListApisRequest
 from axis.models.applications.application import (
     ApplicationStatus,
@@ -385,12 +386,13 @@ async def test_api_request_uses_applications_request_response_type(
 async def test_api_request_returns_raw_bytes_for_request_without_response_type(
     mock_vapix_request, vapix: Vapix
 ):
-    """Verify api_request returns raw bytes for requests without response metadata."""
+    """Verify api_request returns wrapped bytes for requests using byte responses."""
     mock_vapix_request(SetPortsRequest, json={})
 
     response = await vapix.api_request(SetPortsRequest(PortConfiguration(port="0")))
 
-    assert isinstance(response, bytes)
+    assert isinstance(response, BytesResponse)
+    assert isinstance(response.data, bytes)
 
 
 async def test_api_request_decodes_using_request_response_type(


### PR DESCRIPTION
## Summary

This PR makes `ApiRequest` generic using PEP 695 class type parameters and standardizes request/response contracts around the single `Vapix.api_request()` entrypoint.

Example:

```python
response = await vapix.api_request(ListViewAreasRequest())
# inferred: ListViewAreasResponse
```

## What Changed

1. Generic request base
- `ApiRequest` is now `ApiRequest[ResponseT]`.
- Request subclasses declare a runtime decoder through explicit `response_type` metadata.
- The base class no longer relies on an implicit casted default decoder.

2. Single typed request entrypoint
- `Vapix.api_request()` now carries the typed request/response contract directly.
- The old split between raw and typed request helpers is gone.

3. Explicit response contracts on request models
- Read/decoded requests use `ApiRequest[ConcreteResponse]` with `response_type = ConcreteResponse`.
- Write/raw-byte requests use `ApiRequest[ApiResponse[bytes]]` with `response_type = BytesResponse`.
- Contract tests assert that the generic argument and runtime `response_type` stay aligned.

4. Compatibility-preserving handler behavior
- Handlers that historically returned decoded responses still return decoded responses.
- PTZ helper methods intentionally preserve `bytes` return values by unwrapping `.data` at the handler boundary.

5. Documentation and contributor guidance
- Updated `README.md`, `CONTRIBUTING.md`, `COPILOT_QUICK_START.md`, and `.github/copilot-instructions.md` to describe the final request/response typing model.
- Removed redundant `from __future__ import annotations` imports added during the migration where they were not required.

## Why Keep `response_type`?

Type parameters provide static typing, but runtime decoding still needs concrete class metadata. The final design keeps those two layers explicit and aligned:

- Static typing: `ApiRequest[T]`
- Runtime decode: `request.response_type.decode(bytes_data)`

This also avoids hidden defaults by requiring subclasses to declare their decode contract explicitly.

## Validation

- `uv run ruff check axis tests` ✅
- `uv run ruff format --check axis tests` ✅
- `uv run mypy axis` ✅
- `uv run pytest` ✅ (488 passed)
- Coverage: **98%** (required: 95%) ✅

## Risk / Compatibility

- No intended handler API breakage.
- Existing decode behavior is preserved through the single `api_request()` boundary.
- Byte-oriented write requests now have an explicit wrapper contract (`BytesResponse`) instead of relying on implicit behavior.
- Added contract tests reduce the risk of future drift between generic typing and runtime metadata.

## Checklist

- [x] Make `ApiRequest` generic
- [x] Collapse request execution onto `Vapix.api_request()`
- [x] Add explicit runtime `response_type` contracts to request subclasses
- [x] Use `BytesResponse` for write/raw-byte request models
- [x] Preserve handler-level compatibility where bytes are still the public return shape
- [x] Update contract tests and contributor guidance
- [x] Pass lint, format, type-check, tests, and coverage gates
