### PR TITLE
Add PTZ breaking changes

### DIFF
--- a/axis/models/parameters/ptz.py
+++ b/axis/models/parameters/ptz.py
@@ -71,9 +71,9 @@ class PtzSupportParamT(TypedDict):
     ContinuousZoom: bool
     DevicePreset: bool
     DigitalZoom: bool
-    GenericHTTP: bool
+    GenericHTTP: NotRequired[bool]  # Removed with AXIS OS 13
     IrCutFilter: bool
-    JoyStickEmulation: bool
+    JoyStickEmulation: NotRequired[bool]  # Removed with AXIS OS 13
     LensOffset: bool
     OSDMenu: bool
     ProportionalSpeed: bool
@@ -109,7 +109,7 @@ class PtzVariousParamT(TypedDict):
     CtlQueueing: bool
     CtlQueueLimit: int
     CtlQueuePollTime: int
-    HomePresetSet: bool
+    HomePresetSet: NotRequired[bool]  # Removed with AXIS OS 13
     Locked: NotRequired[bool]
     MaxProportionalSpeed: NotRequired[int]
     PanEnabled: NotRequired[bool]
@@ -242,9 +242,9 @@ class PtzSupport:
     continuous_zoom: bool
     device_preset: bool
     digital_zoom: bool
-    generic_http: bool
+    generic_http: bool | None  # Removed with AXIS OS 13
     ir_cut_filter: bool
-    joystick_emulation: bool
+    joystick_emulation: bool | None  # Removed with AXIS OS 13
     lens_offset: bool
     osd_menu: bool
     proportional_speed: bool
@@ -282,9 +282,9 @@ class PtzSupport:
             continuous_zoom=data["ContinuousZoom"],
             device_preset=data["DevicePreset"],
             digital_zoom=data["DigitalZoom"],
-            generic_http=data["GenericHTTP"],
+            generic_http=data.get("GenericHTTP"),
             ir_cut_filter=data["IrCutFilter"],
-            joystick_emulation=data["JoyStickEmulation"],
+            joystick_emulation=data.get("JoyStickEmulation"),
             lens_offset=data["LensOffset"],
             osd_menu=data["OSDMenu"],
             proportional_speed=data["ProportionalSpeed"],
@@ -335,7 +335,7 @@ class PtzVarious:
             control_queueing=data["CtlQueueing"],
             control_queue_limit=data["CtlQueueLimit"],
             control_queue_poll_time=data["CtlQueuePollTime"],
-            home_preset_set=data.get("HomePresetSet"),
+            home_preset_set=data.get("HomePresetSet"),  # Removed with AXIS OS 13
             locked=data.get("Locked", False),
             max_proportional_speed=data.get("MaxProportionalSpeed"),
             pan_enabled=data.get("PanEnabled"),


### PR DESCRIPTION
## What does this PR do?

As reported here https://github.com/home-assistant/core/issues/175458 breaking changes in AXS OS 13 are affecting the library. Going through the list https://help.axis.com/en-us/axis-os#api-changes it seems to only be PTZ related changes currently implemented in the library which is affected.

## Architecture Layer(s)

- [x] Models (`axis/models/`)
- [ ] Interfaces (`axis/interfaces/`)
- [ ] Orchestration (`axis/device.py`, `axis/interfaces/vapix.py`)
- [ ] Tests

## Type of Change

- [ ] New feature (handler, interface, model)
- [x] Bug fix (minimal, targeted)
- [ ] Refactor (no behavior change)
- [ ] Documentation

## Related Issues

Closes #[issue number] (if applicable)

## Verification Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy axis` passes
- [x] `uv run pytest` passes (coverage ≥95%)
- [ ] New tests added for new code (100% coverage for new code)
- [ ] Commit hooks modified files? If so, re-staged and re-ran checks
- [x] No unrelated code/formatting changes
- [ ] Follows conventions: enum `_missing_` fallback, input normalization, XML parsing guards

## Notes for Reviewers

[Context for reviewers: what to focus on, known limitations, decisions made, or why this approach was chosen]
