### PR TITLE
Fix Error: R] [REQUIREMENTS] Version restrictions for zeroconf are too strict (==0.150.0) in axis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies    = [
     "tomli>=2.0",
     "tomli-w>=1.0",
     "xmltodict>=0.13.0",
-    "zeroconf==0.150.0",
+    "zeroconf>=0.150.0",
 ]
 
 [project.optional-dependencies]
@@ -36,7 +36,7 @@ requirements = [
     "orjson==3.11.9",
     "packaging==26.2",
     "xmltodict==1.0.4",
-    "zeroconf==0.150.0",
+    "zeroconf>=0.150.0",
 ]
 requirements-test = [
     "mypy==2.1.0",


### PR DESCRIPTION


## What does this PR do?

Home assistant dependency pinning issue
Fix Error: R] [REQUIREMENTS] Version restrictions for zeroconf are too strict (==0.150.0) in axis

## Architecture Layer(s)

- [ ] Models (`axis/models/`)
- [ ] Interfaces (`axis/interfaces/`)
- [ ] Orchestration (`axis/device.py`, `axis/interfaces/vapix.py`)
- [ ] Tests

## Type of Change

- [ ] New feature (handler, interface, model)
- [ ] Bug fix (minimal, targeted)
- [ ] Refactor (no behavior change)
- [ ] Documentation

## Related Issues

Closes #[issue number] (if applicable)

## Verification Checklist

- [ ] `uv run ruff check .` passes
- [ ] `uv run ruff format --check .` passes
- [ ] `uv run mypy axis` passes
- [ ] `uv run pytest` passes (coverage ≥95%)
- [ ] New tests added for new code (100% coverage for new code)
- [ ] Commit hooks modified files? If so, re-staged and re-ran checks
- [ ] No unrelated code/formatting changes
- [ ] Follows conventions: enum `_missing_` fallback, input normalization, XML parsing guards

## Notes for Reviewers

[Context for reviewers: what to focus on, known limitations, decisions made, or why this approach was chosen]
